### PR TITLE
Add ability to list tests that align with conformance statements

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -120,7 +120,23 @@ namespace :crucible do
 
   desc 'list all'
   task :list_all do
-    puts Crucible::Tests::Executor.list_all
+    require 'turn'
+    require 'benchmark'
+    b = Benchmark.measure { puts Crucible::Tests::Executor.list_all }
+    puts "List all tests completed in #{b.real} seconds."
+  end
+
+  desc 'list all with conformance'
+  task :list_all_w_conf, [:url1, :url2] do |t, args|
+    require 'turn'
+    require 'benchmark'
+    b = Benchmark.measure {
+      client = FHIR::Client.new(args.url1)
+      client2 = FHIR::Client.new(args.url2) if !args.url2.nil?
+      executor = Crucible::Tests::Executor.new(client, client2)
+      puts executor.list_all_with_conformance(!args.url2.nil?)
+    }
+    puts "List all tests with conformance from #{args.url} completed in #{b.real} seconds."
   end
 
   desc 'execute with requirements'

--- a/lib/tests/base_test.rb
+++ b/lib/tests/base_test.rb
@@ -158,19 +158,21 @@ module Crucible
         # array of metadata from current suite's test methods
         suite_metadata = metadata || collect_metadata(true)
         # { fhirType => supported codes }
-        # conformance_resources = Hash[conformance.rest[0].resource.map{ |r| [r.fhirType, r.interaction.map(&:code)]}]
         methods = []
         # include tests with undefined metadata
         methods.push suite_metadata.select{|sm| sm["requires"].blank?}.map {|sm| sm[:test_method]}
         # parse tests with defined metadata
         suite_metadata.select{|sm| !sm["requires"].blank?}.each do |test|
           unsupported = []
+          # determine if any of the metadata requirements match the conformance information
           test["requires"].each do |req|
             diffs = (req[:methods] - ( conformance_resources[req[:resource]] || [] ))
             unsupported.push({req[:resource].to_sym => diffs}) unless diffs.blank?
           end
+          # print debug if unsupported, otherwise add to supported methods
           if !unsupported.blank?
             puts "UNSUPPORTED #{test[:test_method]}: #{unsupported}"
+          else
             methods.push test[:test_method]
           end
         end


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/84777174
### Notes
- testing single server
  - `bundle exec rake crucible:list_all_w_conf["http://bonfire.mitre.org:8090/fhir-dstu2"]`
- testing multiserver
  - `bundle exec rake crucible:list_all_w_conf["http://bonfire.mitre.org:8090/fhir-dstu2","http://fhirtest.uhn.ca/baseDstu2"]`
- testing with Crucible
  - [checkout branch](https://github.com/fhir-crucible/crucible/tree/tests_by_conformance)
  - [see changes](https://github.com/fhir-crucible/crucible/compare/dstu2...tests_by_conformance?expand=1)
