### PR TITLE
Allow subset of tests in a suite to be run

### DIFF
--- a/lib/executor.rb
+++ b/lib/executor.rb
@@ -14,17 +14,13 @@ module Crucible
       end
 
       def execute_all
-        results = []
+        results = {}
         self.tests.each do |test|
           # TODO: Do we want to separate out multiserver tests?
           next if test.multiserver
-          results = results.concat execute(test)
+          results.merge! execute(test)
         end
         results
-      end
-
-      def list_all_with_conformance(multiserver=false, metadata=nil)
-        @suite_engine.list_all_with_conformance(multiserver, metadata) #.merge @testscript_engine.list_all_with_conformance(multiserver, metadata)
       end
 
       def self.list_all(multiserver=false, metadata=false)

--- a/lib/tasks/templates/summary.html.erb
+++ b/lib/tasks/templates/summary.html.erb
@@ -43,11 +43,10 @@
     <% end %>
     </div>
 
-    <% results.each_with_index do |result, index| %>
-      <% suite_key = result.keys.first %>
-      <% suite = result.values.first %>
-      <% errored = suite[:tests].detect{|t| t["status"] == "error"} %>
-      <% failed = suite[:tests].detect{|t| t["status"] == "fail"} || suite[:tests].detect{|t| t["status"] == "pass"}.nil? %>
+    <% results.keys.each_with_index do |suite_key, index| %>
+      <% suite = results[suite_key] %>
+      <% errored = suite.detect{|t| t["status"] == "error"} %>
+      <% failed = suite.detect{|t| t["status"] == "fail"} || suite.detect{|t| t["status"] == "pass"}.nil? %>
       <div class="panel panel-<%= if errored then "danger" elsif failed then "warning" else "success" end %>">
         <div class="panel-heading" role="tab" id="heading<%= index %>">
           <h3 class="panel-title">
@@ -59,7 +58,7 @@
         <div id="collapse<%= index %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading<%= index %>">
           <div class="panel-body">
 
-            <% suite[:tests].each do |test| %>
+            <% suite.each do |test| %>
               <% status_map = {"pass" => "success", "fail" => "warning", "error" => "danger", "skip" => "info"} %>
               <div class="panel panel-<%= status_map[test["status"]]%>">
                 <div class="panel-heading">

--- a/lib/tests/base_test.rb
+++ b/lib/tests/base_test.rb
@@ -7,6 +7,8 @@ module Crucible
       BASE_SPEC_LINK = 'http://hl7.org/fhir/DSTU2'
       REST_SPEC_LINK = "#{BASE_SPEC_LINK}/http.html"
 
+      attr_accessor :tests_subset
+
       # Base test fields, used in Crucible::Tests::Executor.list_all
       JSON_FIELDS = ['author','description','id','tests','title', 'multiserver']
       STATUS = {
@@ -31,13 +33,10 @@ module Crucible
       def execute
         @client.use_format_param = false if @client
         @client2.use_format_param = false if @client2
-        [{title => {
-            test_file: title,
-            tests: execute_test_methods
-        }}]
+        {id => execute_test_methods}
       end
 
-      def execute_test_methods(test_methods=nil)
+      def execute_test_methods
         result = []
         begin
           setup if respond_to? :setup and not @metadata_only
@@ -46,7 +45,7 @@ module Crucible
         end
         prefix = if @metadata_only then 'generating metadata' else 'executing' end
         methods = tests
-        methods = tests & test_methods unless test_methods.blank?
+        methods = tests & @tests_subset unless @tests_subset.blank?
         methods.each do |test_method|
           @client.requests = [] if @client
           puts "[#{title}#{('_' + @resource_class.name.demodulize) if @resource_class}] #{prefix}: #{test_method}..."

--- a/lib/tests/suites/resource_test.rb
+++ b/lib/tests/suites/resource_test.rb
@@ -17,18 +17,14 @@ module Crucible
       def execute(resource_class=nil)
         if resource_class
           @resource_class = resource_class
-          [{"ResourceTest_#{@resource_class.name.demodulize}" => {
-            test_file: title,
-            tests: execute_test_methods
-          }}]
+          {"ResourceTest_#{@resource_class.name.demodulize}" => execute_test_methods}
         else
-          fhir_resources.map do | klass |
+          results = {}
+          fhir_resources.each do | klass |
             @resource_class = klass
-            {"ResourceTest_#{@resource_class.name.demodulize}" => {
-              test_file: title,
-              tests: execute_test_methods
-            }}
+            results.merge!({"ResourceTest_#{@resource_class.name.demodulize}" => execute_test_methods})
           end
+          results
         end
       end
 

--- a/lib/tests/suites/search_test.rb
+++ b/lib/tests/suites/search_test.rb
@@ -10,18 +10,14 @@ module Crucible
       def execute(resource_class=nil)
         if resource_class
           @resource_class = resource_class
-          [{"SearchTest_#{@resource_class.name.demodulize}" => {
-            test_file: title,
-            tests: execute_test_methods
-          }}]
+          {"SearchTest_#{@resource_class.name.demodulize}" => execute_test_methods}
         else
-          fhir_resources.map do | klass |
+          results = {}
+          fhir_resources.each do | klass |
             @resource_class = klass
-            {"SearchTest_#{@resource_class.name.demodulize}" => {
-              test_file: title,
-              tests: execute_test_methods
-            }}
+            results.merge!({"SearchTest_#{@resource_class.name.demodulize}" => execute_test_methods})
           end
+          results
         end
       end
 

--- a/lib/tests/testscripts/base_testscript.rb
+++ b/lib/tests/testscripts/base_testscript.rb
@@ -102,7 +102,7 @@ module Crucible
       def collect_metadata(methods_only=false)
         @metadata_only = true
         result = execute
-        result = result.map{|r| r.values.first[:tests]}.flatten if methods_only
+        result = result.map{|r| r.values.first}.flatten if methods_only
         @metadata_only = false
         result
       end

--- a/lib/tests/testscripts/testscript_engine.rb
+++ b/lib/tests/testscripts/testscript_engine.rb
@@ -8,11 +8,6 @@ module Crucible
         load_testscripts
       end
 
-      def list_all_with_conformance(multiserver=false, metadata=nil)
-        # TODO: Figure out how to build the list of testscripts wrt conformance
-      	{}
-      end
-
       def tests
         @scripts || []
       end

--- a/test/unit/fetch_patient_record_test.rb
+++ b/test/unit/fetch_patient_record_test.rb
@@ -350,8 +350,7 @@ class FetchPatientRecordTest < Test::Unit::TestCase
 
     # only execute the methods that have stubs; remaining methods require complicated stubs
     trackTwoTest = Crucible::Tests::ConnectathonFetchPatientRecordTest.new(client)
-    results = trackTwoTest.execute_test_methods(trackTwoTest.tests(['C8T2_1A', 'C8T2_1B', 'C8T2_2A', 'C8T2_2B', 'C8T2_2C']))
-
+    results = trackTwoTest.execute_test_methods
     assert !results.blank?, 'Failed to execute ConnectathonFetchPatientRecordTest.'
   end
 

--- a/test/unit/financial_test.rb
+++ b/test/unit/financial_test.rb
@@ -31,7 +31,8 @@ class FinancialTest < Test::Unit::TestCase
 
     client = FHIR::Client.new(TESTING_ENDPOINT)
     financial = Crucible::Tests::ConnectathonFinancialTrackTest.new(client)
-    results = financial.execute_test_methods(financial.tests(['C9F_1A', 'C9F_1B']))
+    financial.tests_subset = financial.tests(['C9F_1A', 'C9F_1B'])
+    results = financial.execute_test_methods
 
     assert !results.blank?, 'Failed to execute ConnectathonFinancialTrackTest.'
     assert results.map {|r| r["status"] }.all? {|s| s=="pass"}, "FinacialTest methods did execute succesfully: #{results.map {|r| {r["id"] => r["status"]}}}}."


### PR DESCRIPTION
This allows a subset of tests to be run.
It also makes changes to the output format of suites.  Previously the output format was an array of hashes. Each has had a key for the suite and a value that was a hash with the tests under :tests.  The new format is simply a hash keyed for each suite with the values being an array of the tests. This cleans up a lot of the access code in the crucible web app which used to have to do things like results.first.values.first[:tests].
