### PR TITLE
Run a search for the Patient resource, and limit results to 1

### DIFF
--- a/lib/tests/suites/argonaut_sprint_1_test.rb
+++ b/lib/tests/suites/argonaut_sprint_1_test.rb
@@ -71,8 +71,17 @@ module Crucible
         }
 
         begin
-          @patient_id ||= @client.read_feed(@rc).resource.entry.first.resource.xmlId
-        rescue NoMethodError => e
+          options = {
+            :search => {
+              :flag => true,
+              :compartment => nil,
+              :parameters => {
+                _count: 1
+              }
+            }
+          }
+          @patient_id ||= @client.search(@rc, options).resource.entry.first.resource.xmlId
+        rescue NoMethodError
           @patient = nil
         end
 


### PR DESCRIPTION
This limits the data that needs to be returned when we're only using one Patient, making servers happier and our request viewer faster.
