### PR TITLE
Updated the equality check in Argonaut Sprint 1 

### DIFF
--- a/lib/tests/suites/argonaut_sprint_1_test.rb
+++ b/lib/tests/suites/argonaut_sprint_1_test.rb
@@ -51,7 +51,7 @@ module Crucible
         reply = @client.search(@rc, options)
         assert_response_ok(reply)
         assert_bundle_response(reply)
-        assert reply.resource.get_by_id(@patient_id).equals?(@patient, ['_id', "text"]), 'Server returned wrong patient.'
+        assert reply.resource.get_by_id(@patient_id).equals?(@patient, ['_id', "text", "meta", "lastUpdated"]), 'Server returned wrong patient.'
       end
 
       def define_metadata(method)


### PR DESCRIPTION
Updated to not check `meta` or `lastUpdated` as equal between the `Patient` records, in addition to `_id` and `text`.
