### PR TITLE
Added 'connectathon' tag to relevant test suites

### DIFF
--- a/lib/tests/suites/argonaut_provider_connectathon_test.rb
+++ b/lib/tests/suites/argonaut_provider_connectathon_test.rb
@@ -18,6 +18,7 @@ module Crucible
       def initialize(client1, client2 = nil)
         super(client1, client2)
         @tags.append('provider')
+        @tags.append('connectathon')
         @category = {id: 'argonaut', title: 'Argonaut'}
       end
 

--- a/lib/tests/suites/connectathon_fetch_patient_record.rb
+++ b/lib/tests/suites/connectathon_fetch_patient_record.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/connectathon_financial_track.rb
+++ b/lib/tests/suites/connectathon_financial_track.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/connectathon_genomics_track_test.rb
+++ b/lib/tests/suites/connectathon_genomics_track_test.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/connectathon_lab_order_track.rb
+++ b/lib/tests/suites/connectathon_lab_order_track.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/connectathon_patch_track.rb
+++ b/lib/tests/suites/connectathon_patch_track.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/connectathon_patient_track.rb
+++ b/lib/tests/suites/connectathon_patient_track.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/connectathon_profile_validation.rb
+++ b/lib/tests/suites/connectathon_profile_validation.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/connectathon_scheduling_track.rb
+++ b/lib/tests/suites/connectathon_scheduling_track.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/connectathon_terminology_track.rb
+++ b/lib/tests/suites/connectathon_terminology_track.rb
@@ -12,6 +12,7 @@ module Crucible
 
       def initialize(client1, client2=nil)
         super(client1, client2)
+        @tags.append('connectathon')
         @category = {id: 'connectathon', title: 'Connectathon'}
       end
 

--- a/lib/tests/suites/daf_profiles_test.rb
+++ b/lib/tests/suites/daf_profiles_test.rb
@@ -13,6 +13,7 @@ module Crucible
       def initialize(client1, client2=nil)
         super(client1, client2)
         @tags.append('argonaut')
+        @tags.append('connectathon')
         @category = {id: 'core_functionality', title: 'Core Functionality'}
       end
 


### PR DESCRIPTION
Problem: Connectathon dashboard on projectcrucible.org was empty, because no tests are tagged with the `connectathon` tag (which is different than the category labels).

Solution: Tag the relevant tests with the `connectathon` tag. Also tagged the Data Access Framework (DAF) profiles test, as it's part of the connectathon tracks as well, and the Argonaut Provider Connectathon track.
