### PR TITLE
Made it so sort order isn't checked by version 

### DIFF
--- a/lib/tests/suites/history_test.rb
+++ b/lib/tests/suites/history_test.rb
@@ -187,8 +187,6 @@ module Crucible
           end
         end
 
-        warning { assert_navigation_links(bundle) }
-
         result = @client.resource_history_as_of(FHIR::Patient,after)
         assert_response_ok result
         assert_equal 0, result.resource.total, "Setting since to a future moment still returns history"


### PR DESCRIPTION
when testing whole system history (since different resources can have different version ids while being returned in the correct order). 
