### PR TITLE
Meta Tags

### DIFF
--- a/fixtures/specimen/specimen-register-create.xml
+++ b/fixtures/specimen/specimen-register-create.xml
@@ -42,7 +42,6 @@
 		<reference value="Patient/tlerr"/>
 		<display value="Todd Lerr"/>
 	</subject>
-	</subject>
 	<collection>
 		<collectedDateTime value="2014-12-05"/>
 	</collection>

--- a/lib/daf_resource_generator.rb
+++ b/lib/daf_resource_generator.rb
@@ -6,7 +6,6 @@ module Crucible
         resource = minimal_patient(identifier,name)
         # resource.identifier = [ minimal_identifier(identifier) ]
         # resource.name = [ minimal_humanname(name) ]
-        resource.meta = FHIR::Meta.new
         resource.meta.profile = ['http://hl7.org/fhir/StructureDefinition/daf-patient']
         # DAF must supports and DAF extensions
         resource.active = true

--- a/lib/data/resources.rb
+++ b/lib/data/resources.rb
@@ -14,63 +14,63 @@ module Crucible
       end
 
       def example_patient
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'patient', 'patient-example.xml'))
+        load_fixture('patient/patient-example.xml')
       end
 
       def example_patient_us
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'patient', 'patient-example-us-extensions.xml'))
+        load_fixture('patient/patient-example-us-extensions.xml')
       end
 
       def minimal_patient
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'patient', 'patient-minimal.xml'))
+        load_fixture('patient/patient-minimal.xml')
       end
 
       def example_patient_record_201
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'patient-example-f201-roel.xml'))
+        load_fixture('record/patient-example-f201-roel.xml')
       end
 
       def example_patient_record_condition_201
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'condition-example-f201-fever.xml'))
+        load_fixture('record/condition-example-f201-fever.xml')
       end
 
       def example_patient_record_condition_205
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'condition-example-f205-infection.xml'))
+        load_fixture('record/condition-example-f205-infection.xml')
       end
 
       def example_patient_record_diagnosticreport_201
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'diagnosticreport-example-f201-brainct.xml'))
+        load_fixture('record/diagnosticreport-example-f201-brainct.xml')
       end
 
       def example_patient_record_encounter_201
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'encounter-example-f201-20130404.xml'))
+        load_fixture('record/encounter-example-f201-20130404.xml')
       end
 
       def example_patient_record_encounter_202
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'encounter-example-f202-20130128.xml'))
+        load_fixture('record/encounter-example-f202-20130128.xml')
       end
 
       def example_patient_record_observation_202
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'observation-example-f202-temperature.xml'))
+        load_fixture('record/observation-example-f202-temperature.xml')
       end
 
       def example_patient_record_organization_201
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'organization-example-f201-aumc.xml'))
+        load_fixture('record/organization-example-f201-aumc.xml')
       end
 
       def example_patient_record_organization_203
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'organization-example-f203-bumc.xml'))
+        load_fixture('record/organization-example-f203-bumc.xml')
       end
 
       def example_patient_record_practitioner_201
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'practitioner-example-f201-ab.xml'))
+        load_fixture('record/practitioner-example-f201-ab.xml')
       end
 
       def example_patient_record_procedure_201
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'record', 'procedure-example-f201-tpf.xml'))
+        load_fixture('record/procedure-example-f201-tpf.xml')
       end
 
       def track3_profile
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'validation', 'observation.profile.xml'))
+        load_fixture('validation/observation.profile.xml')
       end
 
       def track3_observations
@@ -78,7 +78,7 @@ module Crucible
         observations = []
         files = File.join(fixture_path, 'validation', 'observations', '*.xml')
         Dir.glob(files).each do |f|
-            observations << FHIR::Xml.from_xml( File.read(f) )
+          observations << tag_metadata(FHIR::Xml.from_xml( File.read(f) ))
         end
         observations
       end
@@ -86,71 +86,80 @@ module Crucible
       # ------------------------------ CLAIM TEST TRACK ------------------------------
 
       def simple_claim
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'financial', 'claim-example.xml'))
+        load_fixture('financial/claim-example.xml')
       end
 
       def average_claim
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'financial', 'claim-example-oral-average.xml'))
+        load_fixture('financial/claim-example-oral-average.xml')
       end
 
       def complex_claim
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'financial', 'claim-example-oral-orthoplan.xml'))
+        load_fixture('financial/claim-example-oral-orthoplan.xml')
       end
 
       # ------------------------------ SCHEDULING TEST TRACK ------------------------------
 
       def scheduling_appointment
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'scheduling', 'appointment-simple.xml'))
+        load_fixture('scheduling/appointment-simple.xml')
       end
 
       def scheduling_response_patient
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'scheduling', 'appointmentresponse-patient-simple.xml'))
+        load_fixture('scheduling/appointmentresponse-patient-simple.xml')
       end
 
       def scheduling_response_practitioner
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'scheduling', 'appointmentresponse-practitioner-simple.xml'))
+        load_fixture('scheduling/appointmentresponse-practitioner-simple.xml')
       end
 
       def scheduling_practitioner
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'scheduling', 'practitioner-simple.xml'))
+        load_fixture('scheduling/practitioner-simple.xml')
       end
 
       def scheduling_schedule
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'scheduling', 'schedule-simple.xml'))
+        load_fixture('scheduling/schedule-simple.xml')
       end
 
       def scheduling_slot
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'scheduling', 'slot-simple.xml'))
+        load_fixture('scheduling/slot-simple.xml')
       end
 
       # ------------------------------ DAF TESTS ------------------------------
 
       def daf_conformance
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'daf', 'conformance-daf-query-responder.xml'))
+        load_fixture('daf/conformance-daf-query-responder.xml')
       end
 
       # ------------------------------ TERMINOLOGY TRACK TESTS ------------------------------
 
       def codesystem_simple
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'terminology', 'codesystem-simple.xml'))
+        load_fixture('terminology/codesystem-simple.xml')
       end
 
       def valueset_simple
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'terminology', 'valueset-example.xml'))
+        load_fixture('terminology/valueset-example.xml')
       end
 
       def conceptmap_simple
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'terminology', 'conceptmap-example.xml'))
+        load_fixture('terminology/conceptmap-example.xml')
       end
 
       # ------------------------------ PATCH TRACK TESTS ------------------------------
 
       def medicationorder_simple
-        FHIR::Xml.from_xml File.read(File.join(fixture_path, 'patch', 'medicationrequest-simple.xml'))
+        load_fixture('patch/medicationrequest-simple.xml')
+      end
+
+      def tag_metadata(resource)
+        if resource.meta.nil?
+          resource.meta = FHIR::Meta.new({ 'tag' => [{'system'=>'http://projectcrucible.org', 'code'=>'testdata'}]})
+        else
+          resource.meta.tag << FHIR::Coding.new({'system'=>'http://projectcrucible.org', 'code'=>'testdata'})
+        end
+        resource
       end
 
       def load_fixture(path)
-        FHIR.from_contents(File.read(File.join(fixture_path, path)))
+        tag_metadata(FHIR.from_contents(File.read(File.join(fixture_path, path))))
       end
 
     end

--- a/lib/data/resources.rb
+++ b/lib/data/resources.rb
@@ -78,7 +78,7 @@ module Crucible
         observations = []
         files = File.join(fixture_path, 'validation', 'observations', '*.xml')
         Dir.glob(files).each do |f|
-          observations << tag_metadata(FHIR::Xml.from_xml( File.read(f) ))
+          observations << Crucible::Generator::Resources.tag_metadata(FHIR::Xml.from_xml( File.read(f) ))
         end
         observations
       end
@@ -149,7 +149,7 @@ module Crucible
         load_fixture('patch/medicationrequest-simple.xml')
       end
 
-      def tag_metadata(resource)
+      def self.tag_metadata(resource)
         if resource.meta.nil?
           resource.meta = FHIR::Meta.new({ 'tag' => [{'system'=>'http://projectcrucible.org', 'code'=>'testdata'}]})
         else
@@ -159,7 +159,7 @@ module Crucible
       end
 
       def load_fixture(path)
-        tag_metadata(FHIR.from_contents(File.read(File.join(fixture_path, path))))
+        Crucible::Generator::Resources.tag_metadata(FHIR.from_contents(File.read(File.join(fixture_path, path))))
       end
 
     end

--- a/lib/resource_generator.rb
+++ b/lib/resource_generator.rb
@@ -162,7 +162,7 @@ module Crucible
         resource = FHIR::Patient.new
         resource.identifier = [ minimal_identifier(identifier) ]
         resource.name = [ minimal_humanname(name) ]
-        resource
+        Crucible::Generator::Resources.tag_metadata(resource)
       end
 
       # Common systems:
@@ -180,7 +180,7 @@ module Crucible
           resource.subject = ref
         end
         resource.valueQuantity = minimal_quantity(value,units)
-        resource
+        Crucible::Generator::Resources.tag_metadata(resource)
       end
 
       # Default system/code are for SNOMED "Obese (finding)"
@@ -194,7 +194,7 @@ module Crucible
         end
         resource.code = minimal_codeableconcept(system,code)
         resource.verificationStatus = 'confirmed'
-        resource
+        Crucible::Generator::Resources.tag_metadata(resource)
       end
 
       def self.minimal_identifier(identifier='0')

--- a/lib/resource_generator.rb
+++ b/lib/resource_generator.rb
@@ -14,6 +14,7 @@ module Crucible
         resource.id=nil if resource.respond_to?(:id=)
         resource.versionId=nil if resource.respond_to?(:versionId=)
         resource.version=nil if resource.respond_to?(:version=)
+        resource.meta=FHIR::Meta.new({ 'tag' => [{'system'=>'http://projectcrucible.org', 'code'=>'testdata'}]}) if resource.respond_to?(:meta=)
         #resource.text=nil if [FHIR::Bundle,FHIR::Binary].include?(klass)
         apply_invariants!(resource)
         resource

--- a/lib/tests/suites/read_test.rb
+++ b/lib/tests/suites/read_test.rb
@@ -23,7 +23,7 @@ module Crucible
         rescue
           # try to create a patient
           begin
-            @patient = FHIR::Patient.create(name: { family: 'Emerald', given: 'Caro' })
+            @patient = FHIR::Patient.new(meta: { tag: [{ system: 'http://projectcrucible.org', code: 'testdata'}] }, name: { family: 'Emerald', given: 'Caro' })
             @patient_created = true
           rescue
             @patient = nil

--- a/lib/tests/suites/sprinkler_search_test.rb
+++ b/lib/tests/suites/sprinkler_search_test.rb
@@ -74,6 +74,7 @@ module Crucible
         body.code = '182756003'
         observation.bodySite = FHIR::CodeableConcept.new
         observation.bodySite.coding = [ body ]
+        Crucible::Generator::Resources.tag_metadata(observation)
         reply = @client.create(observation)
         reply.id
       end

--- a/lib/tests/testscripts/base_testscript.rb
+++ b/lib/tests/testscripts/base_testscript.rb
@@ -108,8 +108,9 @@ module Crucible
 
       def load_fixtures
         @fixtures = {}
+        cgr = Crucible::Generator::Resources.new
         @testscript.fixture.each do |fixture|
-          @fixtures[fixture.id] = get_reference(fixture.resource.reference)
+          @fixtures[fixture.id] = cgr.tag_metadata(get_reference(fixture.resource.reference))
           @fixtures[fixture.id].id = nil unless @fixtures[fixture.id].nil? #fixture resources cannot have an ID
           @autocreate << fixture.id if fixture.autocreate
           @autodelete << fixture.id if fixture.autodelete

--- a/lib/tests/testscripts/base_testscript.rb
+++ b/lib/tests/testscripts/base_testscript.rb
@@ -108,9 +108,8 @@ module Crucible
 
       def load_fixtures
         @fixtures = {}
-        cgr = Crucible::Generator::Resources.new
         @testscript.fixture.each do |fixture|
-          @fixtures[fixture.id] = cgr.tag_metadata(get_reference(fixture.resource.reference))
+          @fixtures[fixture.id] = Crucible::Generator::Resources.tag_metadata(get_reference(fixture.resource.reference))
           @fixtures[fixture.id].id = nil unless @fixtures[fixture.id].nil? #fixture resources cannot have an ID
           @autocreate << fixture.id if fixture.autocreate
           @autodelete << fixture.id if fixture.autodelete

--- a/lib/tests/testscripts/testscript_engine.rb
+++ b/lib/tests/testscripts/testscript_engine.rb
@@ -12,7 +12,7 @@ module Crucible
       end
 
       def tests
-        @scripts
+        @scripts.select{|test| !test.multiserver && !test.containsRuleAssertions?}
       end
 
       def find_test(key)


### PR DESCRIPTION
Ensure that all resources created by Crucible contain a `Resource.meta.tag` identifying the resource as Crucible test data.

Fixes https://github.com/fhir-crucible/crucible/issues/235