### PR TITLE
Add ability to clear responses easily within test for performance rea…

### DIFF
--- a/lib/tests/base_test.rb
+++ b/lib/tests/base_test.rb
@@ -138,6 +138,15 @@ module Crucible
         end
       end
 
+      def mute_response_body(reason = '', &block)
+        return if @client.nil? || !block_given?
+
+        count_before = @client.requests.length
+        yield
+        @client.requests.from(count_before).each { |req| req.response[:body] = reason }
+
+      end
+
     end
   end
 end

--- a/lib/tests/suites/sprinkler_search_test.rb
+++ b/lib/tests/suites/sprinkler_search_test.rb
@@ -35,11 +35,13 @@ module Crucible
         @total_count = 0
         @entries = []
 
-        while reply != nil && !reply.resource.nil?
-          @total_count += reply.resource.entry.size
-          @entries += reply.resource.entry
-          reply = @client.next_page(reply)
-          @read_entire_feed=false if (!reply.nil? && reply.code!=200)
+        mute_response_body 'The body of the Sprinkler Search setup responses are not stored for performance reasons.' do
+          while reply != nil && !reply.resource.nil?
+            @total_count += reply.resource.entry.size
+            @entries += reply.resource.entry
+            reply = @client.next_page(reply)
+            @read_entire_feed=false if (!reply.nil? && reply.code!=200)
+          end
         end
 
         # create a condition matching the first patient


### PR DESCRIPTION
…sons, add to sprinkler setup.

This fixes the problem we have with the sprinkler test having hundreds of very large responses to save in the setup.  I was going back and forth with fixing this on the crucible front-end side vs. here.  On the one hand, this is a crucible interface problem... it poses no problem for the plan executor to have a lot of request/responses in the setup.  However, by putting it in the plan executor, you can specify that certain responses aren't really all that valuable to keep, since there is a low likelyhood somebody will look at them given the context of the suite, but are needed for other tests to run.  If you put it in crucible we would just start throwing away responses somewhat indiscriminately once the data size became too big for our interface (or database) to handle.

I ended up putting it in the plan executor but am open to moving it into crucible if people disagree.