### PR TITLE
Store requests as an extension to operations in TestReport.

### DIFF
--- a/lib/tests/testscripts/base_testscript.rb
+++ b/lib/tests/testscripts/base_testscript.rb
@@ -330,6 +330,8 @@ module Crucible
           'message' => operation.description
           })
 
+        @client.requests = []
+
         requestHeaders = Hash[(operation.requestHeader || []).map{|u| [u.field, u.value]}] #Client needs upgrade to support
         format = FHIR::Formats::ResourceFormat::RESOURCE_XML
         format = FORMAT_MAP[operation.contentType] unless operation.contentType.nil?
@@ -433,6 +435,9 @@ module Crucible
           result.message = "Undefined operation #{operation.type.to_json}"
           FHIR.logger.error(result.message)
         end
+        result.extension.concat(@client.requests.map do |request|
+          FHIR::Extension.new('url' => 'https://projectcrucible.com/extensions/testscript-request', 'valueString' => request.to_json)
+        end)
         handle_response(operation)
         result
       end


### PR DESCRIPTION
We don't have anywhere to store requests when using testscripts and testreports, so I made a dummy extension on operations in testreports so we can pull it back out within crucible.

I didn't put too much thought into how to properly do extensions here -- there isn't actually a structure definition that defines this extension at the URL I provided.  And stuffing everything into a valueString seems a bit hacky, though it is easiest (I just deserialize on the crucible side).  Any suggestions?  I have the crucible front end code ready to pull this out of testreports to put into our standard result format, but will wait for you to approve this before opening that PR (in case I got this completely wrong).