### PR TITLE
Fix test metadata requirements and testscript error.

### DIFF
--- a/lib/tests/suites/connectathon_attachment_track_test.rb
+++ b/lib/tests/suites/connectathon_attachment_track_test.rb
@@ -49,6 +49,15 @@ module Crucible
 
       %w(pdf structured unstructured).each do |att_type|
         test "A13_#{att_type}1", "Submit unsolicited attachment of #{att_type}" do
+          metadata {
+            links "#{REST_SPEC_LINK}#create"
+            links "#{BASE_SPEC_LINK}/patient.html"
+            links "#{BASE_SPEC_LINK}/practitioner.html"
+            links "#{BASE_SPEC_LINK}/communication.html"
+            requires resource: 'Patient', methods: ['create']
+            requires resource: 'Practitioner', methods: ['create']
+            requires resource: 'Communication', methods: ['create']
+          }
           comm = FHIR::Communication.new()
           comm.subject = [@records[:patient].to_reference]
           comm.recipient = [@records[:practitioner].to_reference]
@@ -66,6 +75,15 @@ module Crucible
         end
 
         test "A13_#{att_type}2", "Submit solicited attachment of #{att_type}" do
+          metadata {
+            links "#{REST_SPEC_LINK}#create"
+            links "#{BASE_SPEC_LINK}/patient.html"
+            links "#{BASE_SPEC_LINK}/practitioner.html"
+            links "#{BASE_SPEC_LINK}/communication.html"
+            requires resource: 'Patient', methods: ['create']
+            requires resource: 'Practitioner', methods: ['create']
+            requires resource: 'Communication', methods: ['create']
+          }
           # find a suitable CommunicationRequest to respond to
           options = {
             :search => {

--- a/lib/tests/suites/connectathon_financial_track.rb
+++ b/lib/tests/suites/connectathon_financial_track.rb
@@ -87,8 +87,8 @@ module Crucible
         @client.destroy(FHIR::ClaimResponse, @average_response_id) if !@average_response_id.nil?
         @client.destroy(FHIR::ClaimResponse, @preauth_response_id) if !@preauth_response_id.nil?
         @client.destroy(FHIR::Patient, @patient_id) if !@patient_id.nil?
-        @client.destroy(FHIR::Patient, @organization_1_id) if !@organization_1_id.nil?
-        @client.destroy(FHIR::Patient, @organization_2_id) if !@organization_2_id.nil?
+        @client.destroy(FHIR::Organization, @organization_1_id) if !@organization_1_id.nil?
+        @client.destroy(FHIR::Organization, @organization_2_id) if !@organization_2_id.nil?
         @client.destroy(FHIR::EligibilityRequest, @er_id) if !@er_id.nil?
         @client.destroy(FHIR::Communication, @preauth_communication_id) if !@preauth_communication_id.nil?
       end
@@ -98,7 +98,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#create"
           links "#{BASE_SPEC_LINK}/eligibilityrequest.html"
           links 'http://wiki.hl7.org/index.php?title=201609_Financial_Management#Submit_an_Eligibility.2C_Retrieve.2FReceive_an_EligibilityResponse'
-          requires resource: 'EligibilityRequest', methods: ['create']
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           validates resource: 'EligibilityRequest', methods: ['create']
         }
 
@@ -116,6 +117,10 @@ module Crucible
           links "#{REST_SPEC_LINK}#search"
           links "#{BASE_SPEC_LINK}/eligibilityresponse.html"
           links 'http://wiki.hl7.org/index.php?title=201609_Financial_Management#Submit_an_Eligibility.2C_Retrieve.2FReceive_an_EligibilityResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
+          requires resource: 'EligibilityRequest', methods: ['search']
+          validates resource: 'EligibilityRequest', methods: ['search']
         }
 
         options = {
@@ -153,8 +158,13 @@ module Crucible
           links "#{REST_SPEC_LINK}#create"
           links "#{BASE_SPEC_LINK}/claim.html"
           links 'http://wiki.hl7.org/index.php?title=201609_Financial_Management'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
+          requires resource: 'Claim', methods: ['create']
+          requires resource: 'ClaimResponse', methods: ['search']
+          validates resource: 'Claim', methods: ['create']
+          validates resource: 'ClaimResponse', methods: ['search']
         }
-
 
         reply = @client.create(@preauth)
         assert_response_ok(reply)
@@ -253,6 +263,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#create"
           links "#{BASE_SPEC_LINK}/claim.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'Claim', methods: ['create']
           validates resource: 'Claim', methods: ['create']
         }
@@ -296,6 +308,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#create"
           links "#{BASE_SPEC_LINK}/claim.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'Claim', methods: ['create']
           validates resource: 'Claim', methods: ['create']
         }
@@ -340,6 +354,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#read"
           links "#{BASE_SPEC_LINK}/claim.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'Claim', methods: ['read']
           validates resource: 'Claim', methods: ['read']
         }
@@ -363,6 +379,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#read"
           links "#{BASE_SPEC_LINK}/claim.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'Claim', methods: ['read']
           validates resource: 'Claim', methods: ['read']
         }
@@ -388,6 +406,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#search"
           links "#{BASE_SPEC_LINK}/claimresponse.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'ClaimResponse', methods: ['search']
           validates resource: 'ClaimResponse', methods: ['search']
         }
@@ -423,6 +443,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#search"
           links "#{BASE_SPEC_LINK}/claimresponse.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'ClaimResponse', methods: ['search']
           validates resource: 'ClaimResponse', methods: ['search']
         }
@@ -457,6 +479,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#search"
           links "#{BASE_SPEC_LINK}/claimresponse.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'ClaimResponse', methods: ['search']
           validates resource: 'ClaimResponse', methods: ['search']
         }
@@ -493,6 +517,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#search"
           links "#{BASE_SPEC_LINK}/claimresponse.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'ClaimResponse', methods: ['search']
           validates resource: 'ClaimResponse', methods: ['search']
         }
@@ -528,6 +554,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#search"
           links "#{BASE_SPEC_LINK}/claimresponse.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'ClaimResponse', methods: ['search']
           validates resource: 'ClaimResponse', methods: ['search']
         }
@@ -562,6 +590,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#search"
           links "#{BASE_SPEC_LINK}/claimresponse.html"
           links 'http://wiki.hl7.org/index.php?title=Connectathon9_Financial#Submit_a_Claim_via_REST.2C_Retrieve_a_ClaimResponse'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Organization', methods: ['create']
           requires resource: 'ClaimResponse', methods: ['search']
           validates resource: 'ClaimResponse', methods: ['search']
         }

--- a/lib/tests/suites/connectathon_genomics_track_test.rb
+++ b/lib/tests/suites/connectathon_genomics_track_test.rb
@@ -40,6 +40,8 @@ module Crucible
           links "#{REST_SPEC_LINK}#create"
           links "#{BASE_SPEC_LINK}/sequence.html"
           links 'http://wiki.hl7.org/index.php?title=201605_FHIR_Genomics_on_FHIR_Connectathon_Track_Proposal'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Practitioner', methods: ['create']
           requires resource: 'Sequence', methods: ['create']
           requires resource: 'Specimen', methods: ['create']
           requires resource: 'Observation', methods: ['create']
@@ -71,7 +73,8 @@ module Crucible
           links 'http://wiki.hl7.org/index.php?title=201605_FHIR_Genomics_on_FHIR_Connectathon_Track_Proposal'
           requires resource: 'Sequence', methods: ['read']
           requires resource: 'Observation', methods: ['read']
-          requires resource: 'Patient', methods: ['read']
+          requires resource: 'Patient', methods: ['create','read']
+          requires resource: 'Practitioner', methods: ['create']
         }
 
         options = {
@@ -101,6 +104,7 @@ module Crucible
           requires resource: 'Sequence', methods: ['read']
           requires resource: 'Observation', methods: ['create', 'read']
           requires resource: 'Patient', methods: ['create', 'read']
+          requires resource: 'Practitioner', methods: ['create']
           requires resource: 'Specimen', methods: ['create', 'read']
           requires resource: 'FamilyMemberHistory', methods: ['create', 'read']
           requires resource: 'DiagnosticReport', methods: ['create', 'read']
@@ -146,6 +150,8 @@ module Crucible
         metadata {
           links "#{REST_SPEC_LINK}#search"
           links 'http://wiki.hl7.org/index.php?title=201605_FHIR_Genomics_on_FHIR_Connectathon_Track_Proposal'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Practitioner', methods: ['create']
           requires resource: 'Observation', methods: ['create', 'read']
         }
 
@@ -181,6 +187,8 @@ module Crucible
         metadata {
           links "#{REST_SPEC_LINK}#search"
           links 'http://wiki.hl7.org/index.php?title=201605_FHIR_Genomics_on_FHIR_Connectathon_Track_Proposal'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Practitioner', methods: ['create']
           requires resource: 'DiagnosticReport', methods: ['create', 'read']
           validates resource: 'DiagnosticReport', methods: ['create', 'read']
         }
@@ -206,6 +214,8 @@ module Crucible
         metadata {
           links "#{REST_SPEC_LINK}#search"
           links 'http://wiki.hl7.org/index.php?title=201605_FHIR_Genomics_on_FHIR_Connectathon_Track_Proposal'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Practitioner', methods: ['create']
           requires resource: 'DiagnosticReport', methods: ['create', 'read', 'search', 'delete']
           validates resource: 'DiagnosticReport', methods: ['create', 'read', 'search', 'delete']
         }
@@ -230,6 +240,8 @@ module Crucible
         metadata {
           links "#{REST_SPEC_LINK}#search"
           links 'http://wiki.hl7.org/index.php?title=201605_FHIR_Genomics_on_FHIR_Connectathon_Track_Proposal'
+          requires resource: 'Patient', methods: ['create']
+          requires resource: 'Practitioner', methods: ['create']
           requires resource: 'Sequence', methods: ['read', 'search', 'delete']
           validates resource: 'Sequence', methods: ['read', 'search', 'delete']
         }

--- a/lib/tests/suites/format_test.rb
+++ b/lib/tests/suites/format_test.rb
@@ -28,6 +28,10 @@ module Crucible
 
       # Create a patient and store its details for format requests
       def setup
+        @cached_conformance = @client.capability_statement
+        @supports_xml = @cached_conformance.format.include?('xml')
+        @supports_json = @cached_conformance.format.include?('json')
+
         @resources = Crucible::Generator::Resources.new(fhir_version)
         @resource = @resources.minimal_patient
         @create_failed = false
@@ -72,6 +76,7 @@ module Crucible
           requires resource: 'Patient', methods: ['create','read']
           validates resource: 'Patient', methods: ['read'], formats: ['XML']
         }
+        skip unless @supports_xml
         begin
           patient = request_entry(get_resource(:Patient), @id, @xml_format)
           assert compare_response_format(patient, @xml_format), "XML format header mismatch: requested #{@xml_format}, received #{patient.response_format}"
@@ -90,6 +95,7 @@ module Crucible
             requires resource: 'Patient', methods: ['create','read']
             validates resource: 'Patient', methods: ['read'], formats: ['XML']
           }
+          skip unless @supports_xml
           begin
             wire_format = format
             wire_format = @xml_format if format == 'XML_FORMAT'
@@ -112,6 +118,7 @@ module Crucible
           requires resource: 'Patient', methods: ['create','read']
           validates resource: 'Patient', methods: ['read'], formats: ['JSON']
         }
+        skip unless @supports_json
         begin
           patient = request_entry(get_resource(:Patient), @id, @json_format)
           assert compare_response_format(patient, @json_format), "JSON format header mismatch: requested #{@json_format}, received #{patient.response_format}"
@@ -130,6 +137,7 @@ module Crucible
             requires resource: 'Patient', methods: ['create','read']
             validates resource: 'Patient', methods: ['read'], formats: ['JSON']
           }
+          skip unless @supports_json
           begin
             wire_format = format
             wire_format = @xml_format if format == 'XML_FORMAT'
@@ -152,6 +160,7 @@ module Crucible
           requires resource: 'Patient', methods: ['create','read']
           validates resource: 'Patient', methods: ['read'], formats: ['XML','JSON']
         }
+        skip unless @supports_xml && @supports_json
         begin
           patient_xml = request_entry(get_resource(:Patient), @id, @xml_format)
           patient_json = request_entry(get_resource(:Patient), @id, @json_format)
@@ -173,6 +182,7 @@ module Crucible
           requires resource: 'Patient', methods: ['create','read']
           validates resource: 'Patient', methods: ['read'], formats: ['XML','JSON']
         }
+        skip unless @supports_xml && @supports_json
         begin
           patient_xml = request_entry(get_resource(:Patient), @id, @xml_format, true)
           patient_json = request_entry(get_resource(:Patient), @id, @json_format, true)
@@ -194,6 +204,7 @@ module Crucible
           requires resource: 'Patient', methods: ['create','read']
           validates resource: 'Patient', methods: ['read'], formats: ['XML']
         }
+        skip unless @supports_xml
         begin
           patients_bundle = request_bundle(get_resource(:Patient), @xml_format)
 
@@ -212,6 +223,7 @@ module Crucible
             requires resource: 'Patient', methods: ['create','read']
             validates resource: 'Patient', methods: ['read'], formats: ['XML']
           }
+          skip unless @supports_xml
           begin
             wire_format = format
             wire_format = @xml_format if format == 'XML_FORMAT'
@@ -234,6 +246,7 @@ module Crucible
           requires resource: 'Patient', methods: ['create','read']
           validates resource: 'Patient', methods: ['read'], formats: ['JSON']
         }
+        skip unless @supports_json
         begin
           patients_bundle = request_bundle(get_resource(:Patient), @json_format)
 
@@ -252,6 +265,7 @@ module Crucible
             requires resource: 'Patient', methods: ['create','read']
             validates resource: 'Patient', methods: ['read'], formats: ['JSON']
           }
+          skip unless @supports_json
           begin
             wire_format = format
             wire_format = @xml_format if format == 'XML_FORMAT'

--- a/lib/tests/testscripts/scripts/spec/testscript-example-readtest.xml
+++ b/lib/tests/testscripts/scripts/spec/testscript-example-readtest.xml
@@ -119,7 +119,7 @@
 					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
 					<code value="read"/>
 				</type>
-				<resource value="Patient"/>
+				<resource value="Parameters"/>
 				<description value="Attempt to read the Parameters resource type. What we really want here is an illegal type but the build process won't allow that. Parameters is a valid resource which doesn't have an end-point so, this should fail."/>
 				<accept value="xml"/>
 				<params value="/1"/>


### PR DESCRIPTION
A ran Crucible against a read/create-only server that only supports Patient and Observation.

A number of tests were incorrectly being recommended as "supported only" even though they were not supported.

So, I updated the metadata of those tests.

Also, I fixed a bug with a testscript which was not doing what it claimed it was doing.