### PR TITLE
Fix test order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: ruby
 rvm:
-  - 2.2.7
   - 2.3
   - 2.4
   - 2.5
 before_install:
   - gem update --system
   - gem install bundler
-script: 
+script:
   bundle exec rake test
 notifications:
   email:

--- a/lib/tests/base_test.rb
+++ b/lib/tests/base_test.rb
@@ -18,6 +18,11 @@ module Crucible
       attr_accessor :teardown_requests
       attr_accessor :supported_versions
 
+      # Used to keep track of what order the tests are defined
+      # At some point ruby started not returning the order of methods defined consistently (>2.4ish)
+      # So we need to now save the order that tests were defined
+      @@ordered_tests = []
+
       # Base test fields, used in Crucible::Tests::Executor.list_all
       JSON_FIELDS = ['author','description','id','tests','title', 'multiserver', 'tags', 'details', 'category','supported_versions']
       STATUS = {
@@ -125,7 +130,11 @@ module Crucible
           end
           methods = matches.flatten
         end
-        methods
+        methods.sort {|a, b| @@ordered_tests.index(a) <=> @@ordered_tests.index(b) }
+      end
+
+      def self.store_test_order(test_method)
+        @@ordered_tests << test_method
       end
 
       def warning

--- a/lib/tests/suites/base_suite.rb
+++ b/lib/tests/suites/base_suite.rb
@@ -158,6 +158,9 @@ module Crucible
 
           result
         end
+
+        self.store_test_order(test_method)
+
         define_method test_method, wrapped
       end
 


### PR DESCRIPTION
At some point ruby started not returning methods on classes in the order in which they were defined.  This breaks our tests because they must follow a consistent order.