### PR TITLE
Multiserver evaluate measure testscript

### DIFF
--- a/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
+++ b/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestScript xmlns="http://hl7.org/fhir">
+  <id value="multisystem-evaluate-measure-xml"/>
+
+  <url value="http://example.com"/>
+  <name value="Individual Patient Multisystem TestScript for Evaluating Measures--XML"/>
+  <status value="draft"/>
+  <date value="2019-02-11"/>
+  <publisher value="MITRE"/>
+  <contact>
+    <name value="Matthew Gramigna"/>
+    <telecom>
+      <system value="email"/>
+      <value value="mgramigna@mitre.org"/>
+      <use value="work"/>
+    </telecom>
+  </contact>
+  <description value="Tests using XML format to execute the $evauate-measure operation. The destination server must support the $evaluate-measure operation on the Measure resource."/>
+  <copyright value="N/A"/>
+
+  <fixture id="example-measure">
+    <resource>
+      <reference value="./_reference/resources/Measure/measure-col.json"/>
+    </resource>
+  </fixture>
+
+  <variable>
+    <name value="measureID"/>
+    <defaultValue value="measure-col"/>
+  </variable>
+  <variable>
+    <name value="KnownPatientResourceId"/>
+    <defaultValue value="Patient-6516"/>
+  </variable>
+  <variable>
+    <name value="PeriodStart"/>
+    <defaultValue value="1991-01-01"/>
+  </variable>
+  <variable>
+    <name value="PeriodEnd"/>
+    <defaultValue value="1991-12-31"/>
+  </variable>
+
+  <profile id="measurereport-profile">
+    <reference value="http://hl7.org/fhir/StructureDefinition/MeasureReport"/>
+  </profile>
+
+  <origin>
+    <index value="1" />
+    <profile>
+      <code value="FHIR-Client"/>
+    </profile>
+  </origin>
+  <destination>
+    <index value="1" />
+    <profile>
+      <code value="FHIR-Server"/>
+    </profile>
+  </destination>
+  <destination>
+    <index value="2" />
+    <profile>
+      <code value="FHIR-Server"/>
+    </profile>
+  </destination>
+
+  <test id="Step1-Dest1EvaluateMeasure">
+    <name value="Dest1EvaluateMeasure"/>
+    <description value="Evaluate the measure, no extensions."/>
+
+    <action>
+      <operation>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="evaluate-measure"/>
+        </type>
+        <resource value="Measure"/>
+        <label value="EvaluateMeasure"/>
+        <description value="Evaluate measure with server assigned resource id."/>
+        <accept value="xml"/>
+        <contentType value="xml"/>
+        <destination value="1"/>
+        <url value="Measure/${measureID}/$evaluate-measure?patient=${KnownPatientResourceId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}"/>
+        <responseId value="dest1-measurereport"/>
+      </operation>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP status is 200(OK)"/>
+        <operator value="in"/>
+        <responseCode value="200"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned format is XML. Warning only as the server may not support the return of response content."/>
+        <contentType value="xml"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the return type is MeasureReport. Warning only as the server may not support the return of response content."/>
+        <resource value="MeasureReport"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP Header Last-Modified is present. Warning only as the server may not support versioning."/>
+        <headerField value="Last-Modified"/>
+        <operator value="notEmpty"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP Header ETag is present. Warning only as the server may not support versioning."/>
+        <headerField value="ETag"/>
+        <operator value="notEmpty"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP Header Location is present. Warning only as this is optional but servers are encouraged to return this."/>
+        <headerField value="Location"/>
+        <operator value="notEmpty"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned resource type is MeasureReport."/>
+        <resource value="MeasureReport"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned MeasureReport conforms to the base FHIR specification."/>
+        <validateProfileId value="measurereport-profile"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned MeasureReport contains the expected initial population."/>
+        <operator value="equals"/>
+        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value"/>
+        <value value="1"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned MeasureReport contains the expected denominator."/>
+        <operator value="equals"/>
+        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value"/>
+        <value value="1"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned MeasureReport contains the expected numerator."/>
+        <operator value="equals"/>
+        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value"/>
+        <value value="0"/>
+      </assert>
+    </action>
+  </test>
+
+  <test id="Step2-Dest2EvaluateMeasure">
+    <name value="Dest2EvaluateMeasure"/>
+    <description value="Evaluate the measure, no extensions."/>
+
+    <action>
+      <operation>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="evaluate-measure"/>
+        </type>
+        <resource value="Measure"/>
+        <label value="EvaluateMeasure"/>
+        <description value="Evaluate measure with server assigned resource id."/>
+        <accept value="xml"/>
+        <contentType value="xml"/>
+        <destination value="2"/>
+        <url value="Measure/${measureID}/$evaluate-measure?patient=${KnownPatientResourceId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}"/>
+      </operation>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP status is 200(OK)"/>
+        <operator value="in"/>
+        <responseCode value="200"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned format is XML. Warning only as the server may not support the return of response content."/>
+        <contentType value="xml"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the return type is MeasureReport. Warning only as the server may not support the return of response content."/>
+        <resource value="MeasureReport"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP Header Last-Modified is present. Warning only as the server may not support versioning."/>
+        <headerField value="Last-Modified"/>
+        <operator value="notEmpty"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP Header ETag is present. Warning only as the server may not support versioning."/>
+        <headerField value="ETag"/>
+        <operator value="notEmpty"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP Header Location is present. Warning only as this is optional but servers are encouraged to return this."/>
+        <headerField value="Location"/>
+        <operator value="notEmpty"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned resource type is MeasureReport."/>
+        <resource value="MeasureReport"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned MeasureReport conforms to the base FHIR specification."/>
+        <validateProfileId value="measurereport-profile"/>
+        <warningOnly value="true"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned MeasureReport contains the expected initial population."/>
+        <operator value="equals"/>
+        <compareToSourceId value="dest1-measurereport"/>
+        <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value"/>
+        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned MeasureReport contains the expected denominator."/>
+        <operator value="equals"/>
+        <compareToSourceId value="dest1-measurereport"/>
+        <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value"/>
+        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value"/>
+      </assert>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned MeasureReport contains the expected numerator."/>
+        <operator value="equals"/>
+        <compareToSourceId value="dest1-measurereport"/>
+        <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value" />
+        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value"/>
+      </assert>
+    </action>
+  </test>
+</TestScript>

--- a/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
+++ b/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
@@ -18,27 +18,44 @@
   <description value="Tests using XML format to execute the $evauate-measure operation. The destination server must support the $evaluate-measure operation on the Measure resource."/>
   <copyright value="N/A"/>
 
-  <fixture id="example-measure">
+  <fixture id="library-col-logic">
+    <resource>
+      <reference value="./_reference/resources/Library/library-col-logic.json"/>
+    </resource>
+  </fixture>
+  <fixture id="measure-col">
     <resource>
       <reference value="./_reference/resources/Measure/measure-col.json"/>
     </resource>
   </fixture>
+  <fixture id="fixture-create-patient">
+    <resource>
+      <reference value="./_reference/resources/Patient/test-Patient-410.json"/>
+    </resource>
+  </fixture>
 
   <variable>
-    <name value="measureID"/>
-    <defaultValue value="measure-col"/>
+    <name value="dest1CreateMeasureId"/>
+    <path value="Measure/id" />
+    <sourceId value="dest1-create-measure-response"/>
   </variable>
   <variable>
-    <name value="KnownPatientResourceId"/>
-    <defaultValue value="Patient-6516"/>
+    <name value="dest2CreateMeasureId"/>
+    <path value="Measure/id" />
+    <sourceId value="dest2-create-measure-response"/>
+  </variable>
+  <variable>
+    <name value="createPatientId"/>
+    <defaultValue value="test-Patient-410" />
+    <sourceId value="fixture-create-patient"/>
   </variable>
   <variable>
     <name value="PeriodStart"/>
-    <defaultValue value="1991-01-01"/>
+    <defaultValue value="2017"/>
   </variable>
   <variable>
     <name value="PeriodEnd"/>
-    <defaultValue value="1991-12-31"/>
+    <defaultValue value="2017"/>
   </variable>
 
   <profile id="measurereport-profile">
@@ -64,9 +81,143 @@
     </profile>
   </destination>
 
+  <setup>
+    <action>
+      <operation>
+        <destination value="1"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="create"/>
+        </type>
+        <resource value="Library"/>
+        <description value="Create a library on the first server"/>
+        <accept value="json"/>
+        <contentType value="json"/>
+        <sourceId value="library-col-logic"/>
+      </operation>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP status is 201(Created)."/>
+        <operator value="equals"/>
+        <responseCode value="201"/>
+      </assert>
+    </action>
+    <action>
+      <operation>
+        <destination value="1"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="create"/>
+        </type>
+        <resource value="Measure"/>
+        <description value="Create a measure on the first server"/>
+        <accept value="json"/>
+        <contentType value="json"/>
+        <sourceId value="measure-col"/>
+        <responseId value="dest1-create-measure-response"/>
+      </operation>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP status is 201(Created)."/>
+        <operator value="equals"/>
+        <responseCode value="201"/>
+      </assert>
+    </action>
+    <action>
+      <operation>
+        <destination value="1"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="update"/>
+        </type>
+        <resource value="Patient"/>
+        <description value="Create a patient on the first server"/>
+        <accept value="json"/>
+        <contentType value="json"/>
+        <params value="/${createPatientId}"/>
+        <sourceId value="fixture-create-patient"/>
+      </operation>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+        <operator value="in"/>
+        <responseCode value="200,201"/>
+      </assert>
+    </action>
+    <action>
+      <operation>
+        <destination value="2"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="create"/>
+        </type>
+        <resource value="Library"/>
+        <description value="Create a library on the second server"/>
+        <accept value="json"/>
+        <contentType value="json"/>
+        <sourceId value="library-col-logic"/>
+      </operation>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP status is 201(Created)."/>
+        <operator value="equals"/>
+        <responseCode value="201"/>
+      </assert>
+    </action>
+    <action>
+      <operation>
+        <destination value="2"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="create"/>
+        </type>
+        <resource value="Measure"/>
+        <description value="Create a measure on the second server"/>
+        <accept value="json"/>
+        <contentType value="json"/>
+        <sourceId value="measure-col"/>
+        <responseId value="dest2-create-measure-response"/>
+      </operation>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP status is 201(Created)."/>
+        <operator value="equals"/>
+        <responseCode value="201"/>
+      </assert>
+    </action>
+    <action>
+      <operation>
+        <destination value="2"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="update"/>
+        </type>
+        <resource value="Patient"/>
+        <description value="Create a patient on the second server"/>
+        <accept value="json"/>
+        <contentType value="json"/>
+        <params value="/${createPatientId}"/>
+        <sourceId value="fixture-create-patient"/>
+      </operation>
+    </action>
+    <action>
+      <assert>
+        <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+        <operator value="in"/>
+        <responseCode value="200,201"/>
+      </assert>
+    </action>
+  </setup>
+
+
   <test id="Step1-Dest1EvaluateMeasure">
     <name value="Dest1EvaluateMeasure"/>
-    <description value="Evaluate the measure, no extensions."/>
+    <description value="Evaluate the measure on the first server."/>
 
     <action>
       <operation>
@@ -80,7 +231,7 @@
         <accept value="xml"/>
         <contentType value="xml"/>
         <destination value="1"/>
-        <url value="Measure/${measureID}/$evaluate-measure?patient=${KnownPatientResourceId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}"/>
+        <url value="Measure/${dest1CreateMeasureId}/$evaluate-measure?patient=${createPatientId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}"/>
         <responseId value="dest1-measurereport"/>
       </operation>
     </action>
@@ -157,14 +308,14 @@
         <description value="Confirm that the returned MeasureReport contains the expected numerator."/>
         <operator value="equals"/>
         <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value"/>
-        <value value="0"/>
+        <value value="1"/>
       </assert>
     </action>
   </test>
 
   <test id="Step2-Dest2EvaluateMeasure">
     <name value="Dest2EvaluateMeasure"/>
-    <description value="Evaluate the measure, no extensions."/>
+    <description value="Evaluate the measure on the second server. Compare to results from first server."/>
 
     <action>
       <operation>
@@ -178,7 +329,7 @@
         <accept value="xml"/>
         <contentType value="xml"/>
         <destination value="2"/>
-        <url value="Measure/${measureID}/$evaluate-measure?patient=${KnownPatientResourceId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}"/>
+        <url value="Measure/${dest2CreateMeasureId}/$evaluate-measure?patient=${createPatientId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}"/>
       </operation>
     </action>
     <action>

--- a/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
+++ b/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
@@ -412,4 +412,69 @@
       </assert>
     </action>
   </test>
+
+  <teardown>
+    <action>
+      <operation>
+        <destination value="1"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="delete"/>
+        </type>
+        <resource value="Patient"/>
+        <description value="Delete the patient resource on the first server"/>
+        <targetId value="${createPatientId}"/>
+      </operation>
+      <operation>
+        <destination value="2"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="delete"/>
+        </type>
+        <resource value="Patient"/>
+        <description value="Delete the patient resource on the second server"/>
+        <targetId value="${createPatientId}"/>
+      </operation>
+      <operation>
+        <destination value="1"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="delete"/>
+        </type>
+        <resource value="Measure"/>
+        <description value="Delete the measure resource on the first server"/>
+        <targetId value="${dest1CreateMeasureId}"/>
+      </operation>
+      <operation>
+        <destination value="2"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="delete"/>
+        </type>
+        <resource value="Measure"/>
+        <description value="Delete the measure resource on the second server"/>
+        <targetId value="${dest2CreateMeasureId}"/>
+      </operation>
+      <operation>
+        <destination value="1"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="delete"/>
+        </type>
+        <resource value="Library"/>
+        <description value="Delete the library on the first server"/>
+        <targetId value="library-col-logic"/>
+      </operation>
+      <operation>
+        <destination value="2"/>
+        <type>
+          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+          <code value="delete"/>
+        </type>
+        <resource value="Library"/>
+        <description value="Delete the library on the second server"/>
+        <targetId value="library-col-logic"/>
+      </operation>
+    </action>
+  </teardown>
 </TestScript>

--- a/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
+++ b/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
@@ -131,12 +131,6 @@
     </action>
     <action>
       <assert>
-        <description value="Confirm that the returned resource type is MeasureReport."/>
-        <resource value="MeasureReport"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
         <description value="Confirm that the returned MeasureReport conforms to the base FHIR specification."/>
         <validateProfileId value="measurereport-profile"/>
         <warningOnly value="true"/>
@@ -230,12 +224,6 @@
         <headerField value="Location"/>
         <operator value="notEmpty"/>
         <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned resource type is MeasureReport."/>
-        <resource value="MeasureReport"/>
       </assert>
     </action>
     <action>


### PR DESCRIPTION
Added an example testscript that evaluates the `measure-col` measure against two servers and asserts that the results from the two servers are equal.

`rake crucible:execute_multiserver[<url1>, <url2>, stu3, multisystem-evaluate-measure-xml]`

Note: The test may fail because the output on one server doesn't match the output from the first. The important thing with this testscript is rather the functionality to run evaluate measure on two different destinations, not the value of the results themselves.