### PR TITLE
Check lastUpdated before versionId for sort order in HistoryTest.

### DIFF
--- a/lib/tests/suites/history_test.rb
+++ b/lib/tests/suites/history_test.rb
@@ -303,10 +303,10 @@ module Crucible
         relevant_entries.map!(&:resource).map!(&:meta).compact rescue assert(false, 'Unable to find meta for resources returned by the bundle')
 
         relevant_entries.each_cons(2) do |left, right|
-          if !left.versionId.nil? && !right.versionId.nil?
-            assert (left.versionId > right.versionId), 'Result contains entries in the wrong order.'
-          elsif !left.lastUpdated.nil? && !right.lastUpdated.nil?
+          if !left.lastUpdated.nil? && !right.lastUpdated.nil?
             assert (left.lastUpdated >= right.lastUpdated), 'Result contains entries in the wrong order.'
+          elsif !left.versionId.nil? && !right.versionId.nil?
+            assert (left.versionId > right.versionId), 'Result contains entries in the wrong order.'
           else
             raise AssertionException.new 'Unable to determine if entries are in the correct order -- no meta.versionId or meta.lastUpdated'
           end


### PR DESCRIPTION
The standard doesn't require that version IDs are ordered, see
http://hl7.org/fhir/STU3/resource.html#Meta

Arguably this means that the test shouldn't check version IDs at all
but at least if it checks lastUpdated first it won't fail randomly for
servers that set that but don't have serial version IDs.