### PR TITLE
Update teardown functionality/example testscript

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -268,6 +268,24 @@ namespace :crucible do
       results << Crucible::Tests::TestResult.new(test.name, test.description, status, message, nil).to_hash
       results.last[:test_method] = test.name
     end
+
+    if testreport.teardown
+      statuses = Hash.new(0)
+      message = nil
+      testreport.teardown.action.each do |action|
+        if action.operation
+          statuses[action.operation.result] += 1
+          message = action.operation.message if action.operation.result == 'error' && message.nil? && action.operation.message
+        end
+      end
+      if statuses['error'] > 0
+        status = 'error'
+      else
+        status = 'pass'
+      end
+      results << Crucible::Tests::TestResult.new('TEARDOWN', 'Teardown for TestScript', status, message, nil).to_hash
+      results.last[:test_method] = 'TEARDOWN'
+    end
     results
   end
 

--- a/lib/tests/testscripts/base_testscript.rb
+++ b/lib/tests/testscripts/base_testscript.rb
@@ -298,6 +298,10 @@ module Crucible
           if !@setup_failed
             @current_action = action
             report_setup.action << perform_action(action) 
+            # Update the id_map if using a fixture id
+            if !action.operation.nil? && !action.operation.sourceId.nil?
+              @id_map[action.operation.sourceId] = @last_response.id
+            end
             if action_failed?(report_setup.action.last)
               @setup_failed = true
               @setup_failure_message = 'One of the setup actions failed.'
@@ -449,6 +453,8 @@ module Crucible
             @last_response = client.destroy @fixtures[operation.targetId].class, @id_map[operation.targetId]
             @id_map.delete(operation.targetId)
           end
+          result.result = ( [200,204].include?(@last_response.code) ? 'pass' : 'error' )
+          result.message << " responded with code #{@last_response.code}" if result.result == 'error'
         when '$expand', 'expand'
           result.result = 'error'
           result.message = '$expand not supported'

--- a/lib/tests/testscripts/scripts/spec/testscript-example-setup-teardown.xml
+++ b/lib/tests/testscripts/scripts/spec/testscript-example-setup-teardown.xml
@@ -64,7 +64,7 @@
                     <code value="read"/>
                 </type>
                 <resource value="Patient"/>
-                <description value="Read the known Patient resource on the destination test system using the user defined dynamic variable ${KnownPatientResourceId}."/>
+                <description value="Read the known Patient resource on the destination test system using the user defined dynamic variable ${createPatientId}."/>
                 <accept value="json"/>
                 <params value="/${createPatientId}"/>
             </operation>

--- a/lib/tests/testscripts/scripts/spec/testscript-example-setup-teardown.xml
+++ b/lib/tests/testscripts/scripts/spec/testscript-example-setup-teardown.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestScript xmlns="http://hl7.org/fhir">
+    <id value="testscript-example-setup-teardown"/>
+
+    <url value="http://example.com"/>
+    <name value="Individual Patient Multisystem TestScript for Evaluating Measures--XML"/>
+    <status value="draft"/>
+    <date value="2019-02-11"/>
+    <publisher value="MITRE"/>
+    <contact>
+        <name value="Matthew Gramigna"/>
+        <telecom>
+            <system value="email"/>
+            <value value="mgramigna@mitre.org"/>
+            <use value="work"/>
+        </telecom>
+    </contact>
+    <description value="Tests using XML format to execute the $evauate-measure operation. The destination server must support the $evaluate-measure operation on the Measure resource."/>
+    <copyright value="N/A"/>
+
+    <fixture id="fixture-create-patient">
+        <resource>
+            <reference value="./_reference/resources/patient-example.json"/>
+        </resource>
+    </fixture>
+
+    <variable>
+        <name value="createPatientId"/>
+        <defaultValue value="example" />
+        <sourceId value="fixture-create-patient"/>
+    </variable>
+
+    <setup>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="update"/>
+                </type>
+                <resource value="Patient"/>
+                <description value="Create a patient on the first server"/>
+                <accept value="json"/>
+                <contentType value="json"/>
+                <params value="/${createPatientId}"/>
+                <sourceId value="fixture-create-patient"/>
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                <operator value="in"/>
+                <responseCode value="200,201"/>
+            </assert>
+        </action>
+    </setup>
+
+    <test id="ReadPatient">
+        <name value="Read Patient"/>
+        <description value="Read the patient created during setup"/>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="read"/>
+                </type>
+                <resource value="Patient"/>
+                <description value="Read the known Patient resource on the destination test system using the user defined dynamic variable ${KnownPatientResourceId}."/>
+                <accept value="json"/>
+                <params value="/${createPatientId}"/>
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK)."/>
+                <response value="okay"/>
+            </assert>
+        </action>
+    </test>
+
+    <teardown>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Patient"/>
+                <description value="Delete the patient created"/>
+                <targetId value="fixture-create-patient"/>
+            </operation>
+        </action>
+    </teardown>
+</TestScript>


### PR DESCRIPTION
After some investigation, teardown appeared to be working as expected when using `<params value="/${idToDelete}"/>`, but would fail when using `<targetId value="fixture-to-delete"/>`. The code seemed to be assuming that fixtures were only created using the `autocreate` option. This PR adds code to update the map used for deleting the fixtures when the `autocreate` option is not specified.

There was also no indication of whether or not the teardown section resulted in an error, so I added a small section for that (passes if the delete was successful, fails otherwise).

I added an example testscript with a setup and teardown section that should create/delete a patient. Teardown does not support assertions, so go to the browser to verify that the patient with id `example` was actually deleted after the test runs.

`rake crucible:execute[<url>, stu3, testscript-example-setup-teardown]`