### PR TITLE
$data-requirements support + measure-col example testscript

### DIFF
--- a/lib/tests/assertions.rb
+++ b/lib/tests/assertions.rb
@@ -9,7 +9,7 @@ module Crucible
       end
 
       def assert_equal(expected, actual, message="", data="")
-        actual = actual.to_s
+        actual = actual.to_s if expected.is_a? String
         unless assertion_negated( expected == actual )
           message += " Expected: #{expected}, but found: #{actual}."
           raise AssertionException.new message, data
@@ -17,7 +17,7 @@ module Crucible
       end
 
       def assert_operator(operator, expected, actual, message="", data="")
-        actual = actual.to_s
+        actual = actual.to_s if expected.is_a? String
         case operator
         when :equals
           unless assertion_negated( expected == actual )

--- a/lib/tests/testscripts/base_testscript.rb
+++ b/lib/tests/testscripts/base_testscript.rb
@@ -426,6 +426,15 @@ module Crucible
         when 'submit-data', '$submit-data'
           resource_id = replace_variables(operation.params)
           @last_response = client.post("Measure/#{resource_id}/$submit-data", @fixtures[operation.sourceId], client.fhir_headers({ format: format}))
+        when 'data-requirements', '$data-requirements'
+          if operation.url.nil?
+            resource_id = replace_variables(operation.params)
+            @last_response = client.get "Measure/#{resource_id}/$data-requirements", format
+          else
+            @last_response = client.get replace_variables(operation.url), client.fhir_headers({ format: format })
+            @last_response.resource = FHIR.from_contents(@last_response.body)
+            @last_response.resource_class = @last_response.resource.class
+          end
         when 'transaction'
           result.result = 'error'
           result.message = 'transaction not implemented'

--- a/lib/tests/testscripts/scripts/reporting/data-requirements.xml
+++ b/lib/tests/testscripts/scripts/reporting/data-requirements.xml
@@ -30,10 +30,10 @@
     </fixture>
 
     <variable>
-		<name value="createMeasureId"/>
-		<path value="Measure/id" />
-		<sourceId value="create-measure-response"/>
-	</variable>
+        <name value="createMeasureId"/>
+        <path value="Measure/id"/>
+        <sourceId value="create-measure-response"/>
+    </variable>
 
     <setup>
         <action>
@@ -128,7 +128,7 @@
                 </type>
                 <resource value="Measure"/>
                 <description value="Delete the measure"/>
-                <targetId value="measure-col"/>
+                <params value="/${createMeasureId}"/>
             </operation>
         </action>
     </teardown>

--- a/lib/tests/testscripts/scripts/reporting/data-requirements.xml
+++ b/lib/tests/testscripts/scripts/reporting/data-requirements.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestScript xmlns="http://hl7.org/fhir">
+    <id value="data-requirements"/>
+
+    <url value="http://example.com"/>
+    <name value="Data requirements test for colon cancer measure"/>
+    <status value="draft"/>
+    <date value="2019-03-04"/>
+    <publisher value="MITRE"/>
+    <contact>
+        <name value="Matthew Gramigna"/>
+        <telecom>
+            <system value="email"/>
+            <value value="mgramigna@mitre.org"/>
+            <use value="work"/>
+        </telecom>
+    </contact>
+    <description value="Tests using XML format to execute the $data-requirements operation operation. The destination server must support the $data-requirements operation on the Measure resource."/>
+    <copyright value="N/A"/>
+
+    <fixture id="library-col-logic">
+        <resource>
+            <reference value="./_reference/resources/Library/library-col-logic.json"/>
+        </resource>
+    </fixture>
+    <fixture id="measure-col">
+        <resource>
+            <reference value="./_reference/resources/Measure/measure-col.json"/>
+        </resource>
+    </fixture>
+
+    <variable>
+		<name value="createMeasureId"/>
+		<path value="Measure/id" />
+		<sourceId value="create-measure-response"/>
+	</variable>
+
+    <setup>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="update"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Update or create a library on the server"/>
+                <accept value="json"/>
+                <contentType value="json"/>
+                <params value="/library-col-logic"/>
+                <sourceId value="library-col-logic"/>
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                <operator value="in"/>
+                <responseCode value="200,201"/>
+            </assert>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="create"/>
+                </type>
+                <resource value="Measure"/>
+                <description value="Create a measure on the server"/>
+                <accept value="json"/>
+                <contentType value="json"/>
+                <sourceId value="measure-col"/>
+                <responseId value="create-measure-response"/>
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 201(Created)."/>
+                <response value="created"/>
+            </assert>
+        </action>
+    </setup>
+
+    <test id="TestDataRequirements">
+        <name value="Test Data Requirements"/>
+        <description value="Validate the data requirements for the measure against the logic"/>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="data-requirements"/>
+                </type>
+                <resource value="Measure"/>
+                <description value="Get the data requirements for the measure"/>
+                <accept value="json"/>
+                <contentType value="json"/>
+                <url value="Measure/${createMeasureId}/$data-requirements"/>
+                <responseId value="data-requirements-result"/>
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK)."/>
+                <response value="okay"/>
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the response is a Library resource"/>
+                <resource value="Library"/>
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Verify that the data requirements match those described by the measure logic"/>
+                <operator value="equals"/>
+                <path value="$.dataRequirement"/>
+                <compareToSourceId value="library-col-logic"/>
+                <compareToSourcePath value="$.dataRequirement"/>
+            </assert>
+        </action>
+    </test>
+
+    <teardown>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Measure"/>
+                <description value="Delete the measure"/>
+                <targetId value="measure-col"/>
+            </operation>
+        </action>
+    </teardown>
+</TestScript>


### PR DESCRIPTION
To test: `rake crucible:execute[<server url>, stu3, data-requirements]`

Add support for the `$data-requirements` operation in `base_testscript.rb`. Included an example testscript for testing the data requirements for the colon cancer measure. The data requirements are specified in `library-col-logic.json`. Result of the `$data-requirements` call for `measure-col.json` should match those specified in `library-col-logic.json`.

