### PR TITLE
Allow changes to versionId and lastUpdated.

### DIFF
--- a/lib/tests/suites/format_test.rb
+++ b/lib/tests/suites/format_test.rb
@@ -306,8 +306,12 @@ module Crucible
       private
 
       # Compare requested resource with created resource
+      # @resource is a fixture before it has been posted to the server.
+      # entry is what was returned from a read.
+      # The server is expected to update 'id' and add 'meta.lastUpdated',
+      # and if history is supported add meta.versionId.  Ignore any changes to these.
       def compare_response(entry)
-        !entry.nil? && !entry.resource.nil? && entry.resource.equals?(@resource,['id'])
+        entry&.resource&.equals?(@resource,['id','lastUpdated','versionId']) == true
       end
 
       # Compare response format with requested format
@@ -317,8 +321,7 @@ module Crucible
 
       # Compare two requested entries
       def compare_entries(entry1, entry2)
-        compare_response(entry1) && compare_response(entry2) && entry1.resource.equals?(entry2.resource,['id'])
-      end
+        compare_response(entry1) && compare_response(entry2) && entry1.resource.equals?(entry2.resource,['id']) end
 
       # Unify resource requests and format specification
       def request_entry(resource_class, id, format, use_format_param=false)

--- a/lib/tests/suites/format_test.rb
+++ b/lib/tests/suites/format_test.rb
@@ -321,7 +321,8 @@ module Crucible
 
       # Compare two requested entries
       def compare_entries(entry1, entry2)
-        compare_response(entry1) && compare_response(entry2) && entry1.resource.equals?(entry2.resource,['id']) end
+        compare_response(entry1) && compare_response(entry2) && entry1.resource.equals?(entry2.resource,['id'])
+      end
 
       # Unify resource requests and format specification
       def request_entry(resource_class, id, format, use_format_param=false)


### PR DESCRIPTION
It is valid to change meta.versionId and meta.lastUpdated, as well as id, on the server side when a new resource is created.  Our test incorrectly provided a warning in this case.

Note this only affects the code that checks to see if resource wasn't changed in an invalid way from our pre-post fixture.  We still expect the same resource returned as two different formats to match exactly.