### PR TITLE
Connectathon testscript updates

### DIFF
--- a/lib/tests/testscripts/scripts/reporting/col-data-requirements.xml
+++ b/lib/tests/testscripts/scripts/reporting/col-data-requirements.xml
@@ -67,8 +67,8 @@
                 <description value="Create a measure on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <sourceId value="measure-col"/>
                 <responseId value="create-measure-response"/>
+                <sourceId value="measure-col"/>
             </operation>
         </action>
         <action>
@@ -92,7 +92,7 @@
                 <description value="Get the data requirements for the measure"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <url value="Measure/${createMeasureId}/$data-requirements"/>
+                <params value="/${createMeasureId}/$data-requirements"/>
                 <responseId value="data-requirements-result"/>
             </operation>
         </action>
@@ -111,10 +111,10 @@
         <action>
             <assert>
                 <description value="Verify that the data requirements match those described by the measure logic"/>
-                <operator value="equals"/>
-                <path value="$.dataRequirement"/>
                 <compareToSourceId value="library-col-logic"/>
                 <compareToSourcePath value="$.dataRequirement"/>
+                <operator value="equals"/>
+                <path value="$.dataRequirement"/>
             </assert>
         </action>
     </test>

--- a/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
+++ b/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
@@ -1,480 +1,460 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <TestScript xmlns="http://hl7.org/fhir">
-  <id value="multisystem-evaluate-measure-xml"/>
-
-  <url value="http://example.com"/>
-  <name value="Individual Patient Multisystem TestScript for Evaluating Measures--XML"/>
-  <status value="draft"/>
-  <date value="2019-02-11"/>
-  <publisher value="MITRE"/>
-  <contact>
-    <name value="Matthew Gramigna"/>
-    <telecom>
-      <system value="email"/>
-      <value value="mgramigna@mitre.org"/>
-      <use value="work"/>
-    </telecom>
-  </contact>
-  <description value="Tests using XML format to execute the $evauate-measure operation. The destination server must support the $evaluate-measure operation on the Measure resource."/>
-  <copyright value="N/A"/>
-
-  <fixture id="library-col-logic">
-    <resource>
-      <reference value="./_reference/resources/Library/library-col-logic.json"/>
-    </resource>
-  </fixture>
-  <fixture id="measure-col">
-    <resource>
-      <reference value="./_reference/resources/Measure/measure-col.json"/>
-    </resource>
-  </fixture>
-  <fixture id="fixture-create-patient">
-    <resource>
-      <reference value="./_reference/resources/Patient/test-Patient-410.json"/>
-    </resource>
-  </fixture>
-
-  <variable>
-    <name value="dest1CreateMeasureId"/>
-    <path value="Measure/id" />
-    <sourceId value="dest1-create-measure-response"/>
-  </variable>
-  <variable>
-    <name value="dest2CreateMeasureId"/>
-    <path value="Measure/id" />
-    <sourceId value="dest2-create-measure-response"/>
-  </variable>
-  <variable>
-    <name value="createPatientId"/>
-    <defaultValue value="test-Patient-410" />
-    <sourceId value="fixture-create-patient"/>
-  </variable>
-  <variable>
-    <name value="PeriodStart"/>
-    <defaultValue value="2017"/>
-  </variable>
-  <variable>
-    <name value="PeriodEnd"/>
-    <defaultValue value="2017"/>
-  </variable>
-
-  <profile id="measurereport-profile">
-    <reference value="http://hl7.org/fhir/StructureDefinition/MeasureReport"/>
-  </profile>
-
-  <origin>
-    <index value="1" />
-    <profile>
-      <code value="FHIR-Client"/>
+    <id value="clinical-reasoning-c21-ccs-individual-multisystem-json" />
+    <url value="http://example.com" />
+    <name value="Individual Patient Multisystem TestScript for Evaluating Measures--JSON" />
+    <status value="draft" />
+    <date value="2019-02-11" />
+    <publisher value="MITRE" />
+    <contact>
+        <name value="Matthew Gramigna" />
+        <telecom>
+            <system value="email" />
+            <value value="mgramigna@mitre.org" />
+            <use value="work" />
+        </telecom>
+    </contact>
+    <description value="Tests using JSON format to execute the $evauate-measure operation. The destination server must support the $evaluate-measure operation on the Measure resource." />
+    <copyright value="N/A" />
+    <origin>
+        <index value="1" />
+        <profile>
+            <code value="FHIR-Client" />
+        </profile>
+    </origin>
+    <destination>
+        <index value="1" />
+        <profile>
+            <code value="FHIR-Server" />
+        </profile>
+    </destination>
+    <destination>
+        <index value="2" />
+        <profile>
+            <code value="FHIR-Server" />
+        </profile>
+    </destination>
+    <fixture id="library-col-logic">
+        <resource>
+            <reference value="./_reference/resources/Library/library-col-logic.json" />
+        </resource>
+    </fixture>
+    <fixture id="measure-col">
+        <resource>
+            <reference value="./_reference/resources/Measure/measure-col.json" />
+        </resource>
+    </fixture>
+    <fixture id="fixture-create-patient">
+        <resource>
+            <reference value="./_reference/resources/Patient/test-Patient-410.json" />
+        </resource>
+    </fixture>
+    <profile id="measurereport-profile">
+        <reference value="http://hl7.org/fhir/StructureDefinition/MeasureReport" />
     </profile>
-  </origin>
-  <destination>
-    <index value="1" />
-    <profile>
-      <code value="FHIR-Server"/>
-    </profile>
-  </destination>
-  <destination>
-    <index value="2" />
-    <profile>
-      <code value="FHIR-Server"/>
-    </profile>
-  </destination>
+    <variable>
+        <name value="dest1CreateMeasureId" />
+        <path value="Measure/id" />
+        <sourceId value="dest1-create-measure-response" />
+    </variable>
+    <variable>
+        <name value="dest2CreateMeasureId" />
+        <path value="Measure/id" />
+        <sourceId value="dest2-create-measure-response" />
+    </variable>
+    <variable>
+        <name value="dest1CreatePatientId" />
+        <path value="Patient/id" />
+        <sourceId value="dest1-create-patient-response" />
+    </variable>
+    <variable>
+        <name value="dest2CreatePatientId" />
+        <path value="Patient/id" />
+        <sourceId value="dest2-create-patient-response" />
+    </variable>
+    <variable>
+        <name value="PeriodStart" />
+        <defaultValue value="2017" />
+    </variable>
+    <variable>
+        <name value="PeriodEnd" />
+        <defaultValue value="2017" />
+    </variable>
 
-  <setup>
-    <action>
-      <operation>
-        <destination value="1"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="create"/>
-        </type>
-        <resource value="Library"/>
-        <description value="Create a library on the first server"/>
-        <accept value="json"/>
-        <contentType value="json"/>
-        <sourceId value="library-col-logic"/>
-      </operation>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP status is 201(Created)."/>
-        <operator value="equals"/>
-        <responseCode value="201"/>
-      </assert>
-    </action>
-    <action>
-      <operation>
-        <destination value="1"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="create"/>
-        </type>
-        <resource value="Measure"/>
-        <description value="Create a measure on the first server"/>
-        <accept value="json"/>
-        <contentType value="json"/>
-        <sourceId value="measure-col"/>
-        <responseId value="dest1-create-measure-response"/>
-      </operation>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP status is 201(Created)."/>
-        <operator value="equals"/>
-        <responseCode value="201"/>
-      </assert>
-    </action>
-    <action>
-      <operation>
-        <destination value="1"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="update"/>
-        </type>
-        <resource value="Patient"/>
-        <description value="Create a patient on the first server"/>
-        <accept value="json"/>
-        <contentType value="json"/>
-        <params value="/${createPatientId}"/>
-        <sourceId value="fixture-create-patient"/>
-      </operation>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
-        <operator value="in"/>
-        <responseCode value="200,201"/>
-      </assert>
-    </action>
-    <action>
-      <operation>
-        <destination value="2"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="create"/>
-        </type>
-        <resource value="Library"/>
-        <description value="Create a library on the second server"/>
-        <accept value="json"/>
-        <contentType value="json"/>
-        <sourceId value="library-col-logic"/>
-      </operation>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP status is 201(Created)."/>
-        <operator value="equals"/>
-        <responseCode value="201"/>
-      </assert>
-    </action>
-    <action>
-      <operation>
-        <destination value="2"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="create"/>
-        </type>
-        <resource value="Measure"/>
-        <description value="Create a measure on the second server"/>
-        <accept value="json"/>
-        <contentType value="json"/>
-        <sourceId value="measure-col"/>
-        <responseId value="dest2-create-measure-response"/>
-      </operation>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP status is 201(Created)."/>
-        <operator value="equals"/>
-        <responseCode value="201"/>
-      </assert>
-    </action>
-    <action>
-      <operation>
-        <destination value="2"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="update"/>
-        </type>
-        <resource value="Patient"/>
-        <description value="Create a patient on the second server"/>
-        <accept value="json"/>
-        <contentType value="json"/>
-        <params value="/${createPatientId}"/>
-        <sourceId value="fixture-create-patient"/>
-      </operation>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
-        <operator value="in"/>
-        <responseCode value="200,201"/>
-      </assert>
-    </action>
-  </setup>
+    <setup>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="update" />
+                </type>
+                <resource value="Library" />
+                <description value="Create or update a library on the first server" />
+                <accept value="json" />
+                <contentType value="json" />
+                <destination value="1" />
+                <params value="/library-col-logic" />
+                <sourceId value="library-col-logic" />
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+                <operator value="in" />
+                <responseCode value="200,201" />
+            </assert>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="create" />
+                </type>
+                <resource value="Measure" />
+                <description value="Create a measure on the first server" />
+                <accept value="json" />
+                <contentType value="json" />
+                <destination value="1" />
+                <responseId value="dest1-create-measure-response" />
+                <sourceId value="measure-col" />
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 201(Created)." />
+                <response value="created" />
+            </assert>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="create" />
+                </type>
+                <resource value="Patient" />
+                <description value="Create a patient on the first server" />
+                <accept value="json" />
+                <contentType value="json" />
+                <destination value="1" />
+                <responseId value="dest1-create-patient-response" />
+                <sourceId value="fixture-create-patient" />
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 201(Created)." />
+                <response value="created" />
+            </assert>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="update" />
+                </type>
+                <resource value="Library" />
+                <description value="Create or update a library on the first server" />
+                <accept value="json" />
+                <contentType value="json" />
+                <destination value="2" />
+                <params value="/library-col-logic" />
+                <sourceId value="library-col-logic" />
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+                <operator value="in" />
+                <responseCode value="200,201" />
+            </assert>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="create" />
+                </type>
+                <resource value="Measure" />
+                <description value="Create a measure on the second server" />
+                <accept value="json" />
+                <contentType value="json" />
+                <destination value="2" />
+                <responseId value="dest2-create-measure-response" />
+                <sourceId value="measure-col" />
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 201(Created)." />
+                <response value="created" />
+            </assert>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="create" />
+                </type>
+                <resource value="Patient" />
+                <description value="Create a patient on the second server" />
+                <accept value="json" />
+                <contentType value="json" />
+                <destination value="2" />
+                <responseId value="dest2-create-patient-response" />
+                <sourceId value="fixture-create-patient" />
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK)" />
+                <response value="created" />
+            </assert>
+        </action>
+    </setup>
 
+    <test id="Step1-Dest1EvaluateMeasure">
+        <name value="Dest1EvaluateMeasure" />
+        <description value="Evaluate the measure on the first server." />
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="evaluate-measure" />
+                </type>
+                <resource value="Measure" />
+                <label value="EvaluateMeasure" />
+                <description value="Evaluate measure with server assigned resource id." />
+                <accept value="xml" />
+                <contentType value="xml" />
+                <destination value="1" />
+                <params value="/${dest1CreateMeasureId}/$evaluate-measure?patient=${dest1CreatePatientId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}" />
+                <responseId value="dest1-measurereport" />
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK)" />
+                <response value="okay" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned format is XML. Warning only as the server may not support the return of response content." />
+                <contentType value="xml" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the return type is MeasureReport. Warning only as the server may not support the return of response content." />
+                <resource value="MeasureReport" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP Header Last-Modified is present. Warning only as the server may not support versioning." />
+                <headerField value="Last-Modified" />
+                <operator value="notEmpty" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP Header ETag is present. Warning only as the server may not support versioning." />
+                <headerField value="ETag" />
+                <operator value="notEmpty" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP Header Location is present. Warning only as this is optional but servers are encouraged to return this." />
+                <headerField value="Location" />
+                <operator value="notEmpty" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned MeasureReport conforms to the base FHIR specification." />
+                <validateProfileId value="measurereport-profile" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned MeasureReport contains the expected initial population." />
+                <operator value="equals" />
+                <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value" />
+                <value value="1" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned MeasureReport contains the expected denominator." />
+                <operator value="equals" />
+                <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value" />
+                <value value="1" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned MeasureReport contains the expected numerator." />
+                <operator value="equals" />
+                <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value" />
+                <value value="1" />
+            </assert>
+        </action>
+    </test>
 
-  <test id="Step1-Dest1EvaluateMeasure">
-    <name value="Dest1EvaluateMeasure"/>
-    <description value="Evaluate the measure on the first server."/>
+    <test id="Step2-Dest2EvaluateMeasure">
+        <name value="Dest2EvaluateMeasure" />
+        <description value="Evaluate the measure on the second server. Compare to results from first server." />
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="evaluate-measure" />
+                </type>
+                <resource value="Measure" />
+                <label value="EvaluateMeasure" />
+                <description value="Evaluate measure with server assigned resource id." />
+                <accept value="xml" />
+                <contentType value="xml" />
+                <destination value="2" />
+                <params value="/${dest2CreateMeasureId}/$evaluate-measure?patient=${dest2CreatePatientId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}" />
+            </operation>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK)" />
+                <operator value="in" />
+                <responseCode value="200" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned format is XML. Warning only as the server may not support the return of response content." />
+                <contentType value="xml" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the return type is MeasureReport. Warning only as the server may not support the return of response content." />
+                <resource value="MeasureReport" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP Header Last-Modified is present. Warning only as the server may not support versioning." />
+                <headerField value="Last-Modified" />
+                <operator value="notEmpty" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP Header ETag is present. Warning only as the server may not support versioning." />
+                <headerField value="ETag" />
+                <operator value="notEmpty" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned HTTP Header Location is present. Warning only as this is optional but servers are encouraged to return this." />
+                <headerField value="Location" />
+                <operator value="notEmpty" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned MeasureReport conforms to the base FHIR specification." />
+                <validateProfileId value="measurereport-profile" />
+                <warningOnly value="true" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned MeasureReport contains the expected initial population." />
+                <compareToSourceId value="dest1-measurereport" />
+                <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value" />
+                <operator value="equals" />
+                <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned MeasureReport contains the expected denominator." />
+                <compareToSourceId value="dest1-measurereport" />
+                <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value" />
+                <operator value="equals" />
+                <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value" />
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <description value="Confirm that the returned MeasureReport contains the expected numerator." />
+                <compareToSourceId value="dest1-measurereport" />
+                <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value" />
+                <operator value="equals" />
+                <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value" />
+            </assert>
+        </action>
+    </test>
 
-    <action>
-      <operation>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="evaluate-measure"/>
-        </type>
-        <resource value="Measure"/>
-        <label value="EvaluateMeasure"/>
-        <description value="Evaluate measure with server assigned resource id."/>
-        <accept value="xml"/>
-        <contentType value="xml"/>
-        <destination value="1"/>
-        <url value="Measure/${dest1CreateMeasureId}/$evaluate-measure?patient=${createPatientId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}"/>
-        <responseId value="dest1-measurereport"/>
-      </operation>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP status is 200(OK)"/>
-        <operator value="in"/>
-        <responseCode value="200"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned format is XML. Warning only as the server may not support the return of response content."/>
-        <contentType value="xml"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the return type is MeasureReport. Warning only as the server may not support the return of response content."/>
-        <resource value="MeasureReport"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP Header Last-Modified is present. Warning only as the server may not support versioning."/>
-        <headerField value="Last-Modified"/>
-        <operator value="notEmpty"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP Header ETag is present. Warning only as the server may not support versioning."/>
-        <headerField value="ETag"/>
-        <operator value="notEmpty"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP Header Location is present. Warning only as this is optional but servers are encouraged to return this."/>
-        <headerField value="Location"/>
-        <operator value="notEmpty"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned MeasureReport conforms to the base FHIR specification."/>
-        <validateProfileId value="measurereport-profile"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned MeasureReport contains the expected initial population."/>
-        <operator value="equals"/>
-        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value"/>
-        <value value="1"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned MeasureReport contains the expected denominator."/>
-        <operator value="equals"/>
-        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value"/>
-        <value value="1"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned MeasureReport contains the expected numerator."/>
-        <operator value="equals"/>
-        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value"/>
-        <value value="1"/>
-      </assert>
-    </action>
-  </test>
-
-  <test id="Step2-Dest2EvaluateMeasure">
-    <name value="Dest2EvaluateMeasure"/>
-    <description value="Evaluate the measure on the second server. Compare to results from first server."/>
-
-    <action>
-      <operation>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="evaluate-measure"/>
-        </type>
-        <resource value="Measure"/>
-        <label value="EvaluateMeasure"/>
-        <description value="Evaluate measure with server assigned resource id."/>
-        <accept value="xml"/>
-        <contentType value="xml"/>
-        <destination value="2"/>
-        <url value="Measure/${dest2CreateMeasureId}/$evaluate-measure?patient=${createPatientId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}"/>
-      </operation>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP status is 200(OK)"/>
-        <operator value="in"/>
-        <responseCode value="200"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned format is XML. Warning only as the server may not support the return of response content."/>
-        <contentType value="xml"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the return type is MeasureReport. Warning only as the server may not support the return of response content."/>
-        <resource value="MeasureReport"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP Header Last-Modified is present. Warning only as the server may not support versioning."/>
-        <headerField value="Last-Modified"/>
-        <operator value="notEmpty"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP Header ETag is present. Warning only as the server may not support versioning."/>
-        <headerField value="ETag"/>
-        <operator value="notEmpty"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned HTTP Header Location is present. Warning only as this is optional but servers are encouraged to return this."/>
-        <headerField value="Location"/>
-        <operator value="notEmpty"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned MeasureReport conforms to the base FHIR specification."/>
-        <validateProfileId value="measurereport-profile"/>
-        <warningOnly value="true"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned MeasureReport contains the expected initial population."/>
-        <operator value="equals"/>
-        <compareToSourceId value="dest1-measurereport"/>
-        <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value"/>
-        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned MeasureReport contains the expected denominator."/>
-        <operator value="equals"/>
-        <compareToSourceId value="dest1-measurereport"/>
-        <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value"/>
-        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value"/>
-      </assert>
-    </action>
-    <action>
-      <assert>
-        <description value="Confirm that the returned MeasureReport contains the expected numerator."/>
-        <operator value="equals"/>
-        <compareToSourceId value="dest1-measurereport"/>
-        <compareToSourcePath value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value" />
-        <path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value"/>
-      </assert>
-    </action>
-  </test>
-
-  <teardown>
-    <action>
-      <operation>
-        <destination value="1"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="delete"/>
-        </type>
-        <resource value="Patient"/>
-        <description value="Delete the patient resource on the first server"/>
-        <targetId value="${createPatientId}"/>
-      </operation>
-      <operation>
-        <destination value="2"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="delete"/>
-        </type>
-        <resource value="Patient"/>
-        <description value="Delete the patient resource on the second server"/>
-        <targetId value="${createPatientId}"/>
-      </operation>
-      <operation>
-        <destination value="1"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="delete"/>
-        </type>
-        <resource value="Measure"/>
-        <description value="Delete the measure resource on the first server"/>
-        <targetId value="${dest1CreateMeasureId}"/>
-      </operation>
-      <operation>
-        <destination value="2"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="delete"/>
-        </type>
-        <resource value="Measure"/>
-        <description value="Delete the measure resource on the second server"/>
-        <targetId value="${dest2CreateMeasureId}"/>
-      </operation>
-      <operation>
-        <destination value="1"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="delete"/>
-        </type>
-        <resource value="Library"/>
-        <description value="Delete the library on the first server"/>
-        <targetId value="library-col-logic"/>
-      </operation>
-      <operation>
-        <destination value="2"/>
-        <type>
-          <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-          <code value="delete"/>
-        </type>
-        <resource value="Library"/>
-        <description value="Delete the library on the second server"/>
-        <targetId value="library-col-logic"/>
-      </operation>
-    </action>
-  </teardown>
+    <teardown>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="delete" />
+                </type>
+                <resource value="Patient" />
+                <description value="Delete the patient resource on the first server" />
+                <destination value="1" />
+                <params value="/${dest1CreatePatientId}" />
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="delete" />
+                </type>
+                <resource value="Patient" />
+                <description value="Delete the patient resource on the second server" />
+                <destination value="2" />
+                <params value="/${dest2CreatePatientId}" />
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="delete" />
+                </type>
+                <resource value="Measure" />
+                <description value="Delete the measure resource on the first server" />
+                <destination value="1" />
+                <params value="/${dest1CreateMeasureId}" />
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="delete" />
+                </type>
+                <resource value="Measure" />
+                <description value="Delete the measure resource on the second server" />
+                <destination value="2" />
+                <params value="/${dest2CreateMeasureId}" />
+            </operation>
+        </action>
+    </teardown>
 </TestScript>

--- a/lib/tests/testscripts/scripts/reporting/submit-data.xml
+++ b/lib/tests/testscripts/scripts/reporting/submit-data.xml
@@ -1,232 +1,257 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <TestScript xmlns="http://hl7.org/fhir">
-	<id value="testscript-example-submit-data"/>
-
-	<url value="http://example.com"/>
-	<version value="1.0"/>
-	<name value="Submit Data"/>
-	<status value="draft"/>
-	<date value="2018-11-28"/>
-	<publisher value=""/>
+	<id value="testscript-example-submit-data" />
+	<url value="http://example.com" />
+	<version value="1.0" />
+	<name value="Submit Data" />
+	<status value="draft" />
+	<date value="2018-11-28" />
+	<publisher value="MITRE" />
 	<contact>
-		<name value="Tom Strassner"/>
+		<name value="Tom Strassner" />
 		<telecom>
-			<system value="email"/>
-			<value value="tstrassner@mitre.org"/>
-			<use value="work"/>
+			<system value="email" />
+			<value value="tstrassner@mitre.org" />
+			<use value="work" />
 		</telecom>
 	</contact>
-	<description value= "TestScript resource with submit-data test."/>
+	<description value="TestScript resource with submit-data test." />
 	<jurisdiction>
 		<coding>
-			<system value="urn:iso:std:iso:3166"/>
-			<code value="US"/>
-			<display value="United States of America (the)"/>
+			<system value="urn:iso:std:iso:3166" />
+			<code value="US" />
+			<display value="United States of America (the)" />
 		</coding>
 	</jurisdiction>
-
 	<fixture id="library-col-logic">
 		<resource>
-			<reference value="./_reference/resources/Library/library-col-logic.json"/>
+			<reference value="./_reference/resources/Library/library-col-logic.json" />
 		</resource>
 	</fixture>
 	<fixture id="measure-col">
 		<resource>
-			<reference value="./_reference/resources/Measure/measure-col.json"/>
+			<reference value="./_reference/resources/Measure/measure-col.json" />
 		</resource>
 	</fixture>
 	<fixture id="fixture-create-patient">
 		<resource>
-			<reference value="./_reference/resources/Patient/test-Patient-410.json"/>
+			<reference value="./_reference/resources/Patient/test-Patient-410.json" />
 		</resource>
 	</fixture>
 	<fixture id="submit-data-parameters">
 		<resource>
-			<reference value="./_reference/resources/submit-data-parameters.json"/>
+			<reference value="./_reference/resources/submit-data-parameters.json" />
 		</resource>
 	</fixture>
-
 	<variable>
-		<name value="createMeasureId"/>
+		<name value="createMeasureId" />
 		<path value="Measure/id" />
-		<sourceId value="create-measure-response"/>
+		<sourceId value="create-measure-response" />
 	</variable>
 	<variable>
-		<name value="createPatientId"/>
+		<name value="createPatientId" />
 		<defaultValue value="test-Patient-410" />
-		<sourceId value="fixture-create-patient"/>
+		<sourceId value="fixture-create-patient" />
 	</variable>
-	
-	<test id="SubmitData">
-		<name value="Submit Data"/>
-		<description value="Submit measure data for a patient."/>
+
+	<setup>
 		<action>
 			<operation>
 				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
-					<code value="create"/>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="update" />
 				</type>
-				<resource value="Library"/>
-				<description value="Create a library"/>
-				<accept value="json"/>
-				<contentType value="json"/>
+				<resource value="Library" />
+				<description value="Create or update a library" />
+				<accept value="json" />
+				<contentType value="json" />
+				<params value="/library-col-logic" />
 				<sourceId value="library-col-logic"/>
 			</operation>
 		</action>
 		<action>
-			<operation>
-				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
-					<code value="create"/>
-				</type>
-				<resource value="Measure"/>
-				<description value="Create a measure"/>
-				<accept value="json"/>
-				<contentType value="json"/>
-				<sourceId value="measure-col"/>
-				<responseId value="create-measure-response"/>
-			</operation>
-		</action>
-		<action>
-			<operation>
-				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
-					<code value="update"/>
-				</type>
-				<resource value="Patient"/>
-				<description value="Create a patient"/>
-				<accept value="json"/>
-				<contentType value="json"/>
-				<params value="/${createPatientId}"/>
-				<sourceId value="fixture-create-patient"/>
-			</operation>
-		</action>
-		<action>
 			<assert>
-				<description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
-				<operator value="in"/>
-				<responseCode value="200,201"/>
+				<description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+				<operator value="in" />
+				<responseCode value="200,201" />
 			</assert>
 		</action>
 		<action>
 			<operation>
 				<type>
-					<code value="submit-data"/>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="create" />
 				</type>
-				<resource value="Measure"/>
-				<description value="Submit data for a measure."/>
-				<accept value="json"/>
-				<contentType value="json"/>
-				<params value="/${createMeasureId}"/>				
-				<encodeRequestUrl value="false"/>
-				<sourceId value="submit-data-parameters"/>
+				<resource value="Measure" />
+				<description value="Create a measure" />
+				<accept value="json" />
+				<contentType value="json" />
+				<responseId value="create-measure-response" />
+				<sourceId value="measure-col" />
 			</operation>
 		</action>
 		<action>
 			<assert>
-				<description value="Confirm that the returned HTTP status is 200(OK)."/>
-				<direction value="response"/>
-				<responseCode value="200"/>
+				<description value="Confirm that the returned HTTP status is 201 (Created)" />
+				<response value="created" />
 			</assert>
 		</action>
 		<action>
 			<operation>
 				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
-					<code value="evaluate-measure"/>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="update" />
 				</type>
-				<resource value="Measure"/>
-				<description value="Evaluate a measure."/>
-				<accept value="json"/>
-				<contentType value="json"/>
-				<url value="Measure/${createMeasureId}/$evaluate-measure?patient=${createPatientId}&amp;periodStart=2017&amp;periodEnd=2017"/>
-				<responseId value="measure-calc-report"/>
+				<resource value="Patient" />
+				<description value="Create a patient" />
+				<accept value="json" />
+				<contentType value="json" />
+				<params value="/${createPatientId}" />
+				<sourceId value="fixture-create-patient" />
 			</operation>
 		</action>
 		<action>
 			<assert>
-				<description value="Confirm that the returned HTTP status is 200(OK)."/>
-				<direction value="response"/>
-				<responseCode value="200"/>
+				<description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+				<operator value="in" />
+				<responseCode value="200,201" />
 			</assert>
+		</action>
+	</setup>
+
+	<test id="01-SubmitData">
+		<name value="Submit Data" />
+		<description value="Submit measure data for a patient." />
+		<action>
+			<operation>
+				<type>
+					<code value="submit-data" />
+				</type>
+				<resource value="Measure" />
+				<description value="Submit data for a measure." />
+				<accept value="json" />
+				<contentType value="json" />
+				<encodeRequestUrl value="false" />
+				<params value="/${createMeasureId}" />
+				<sourceId value="submit-data-parameters" />
+			</operation>
 		</action>
 		<action>
 			<assert>
-				<description value="Confirm that the returned format is JSON. Warning only as the server may not support the return of response content."/>
-				<contentType value="json"/>
-				<warningOnly value="true"/>
-			</assert>
-		</action>
-		<action>
-			<assert>
-				<description value="Confirm that the return type is MeasureReport. Warning only as the server may not support the return of response content."/>
-				<resource value="MeasureReport"/>
-			</assert>
-		</action>
-		<action>
-			<assert>
-				<description value="Confirm that the returned MeasureReport contains the expected initial population."/>
-				<operator value="equals"/>
-				<path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value"/>
-				<value value="1"/>
-			</assert>
-		</action>
-		<action>
-			<assert>
-				<description value="Confirm that the returned MeasureReport contains the expected denominator."/>
-				<operator value="equals"/>
-				<path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value"/>
-				<value value="1"/>
-			</assert>
-		</action>
-		<action>
-			<assert>
-				<description value="Confirm that the returned MeasureReport contains the expected numerator."/>
-				<operator value="equals"/>
-				<path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value"/>
-				<value value="1"/>
+				<description value="Confirm that the returned HTTP status is 200(OK)." />
+				<direction value="response" />
+				<responseCode value="200" />
 			</assert>
 		</action>
 	</test>
 
-	<teardown>
+	<test id="02-EvaluateMeasure">
+		<name value="Evaluate Measure" />
+		<description value="Evaluate the measure for the individual using the submitted data for the Measure" />
 		<action>
 			<operation>
 				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
-					<code value="delete"/>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="evaluate-measure" />
 				</type>
-				<resource value="Patient"/>
-				<description value="Delete the patient resource on the test server using the id of the Patient."/>
-				<targetId value="${createPatientId}"/>
-			</operation>
-			<operation>
-				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
-					<code value="delete"/>
-				</type>
-				<resource value="Observation"/>
-				<description value="Delete the observation on the test server using the id of the Observation"/>
-				<targetId value="test-Observation-32794"/>
-			</operation>
-			<operation>
-				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
-					<code value="delete"/>
-				</type>
-				<resource value="Measure"/>
-				<description value="Delete the measure resource on the test server"/>
-				<targetId value="${createMeasureId}"/>
-			</operation>
-			<operation>
-				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
-					<code value="delete"/>
-				</type>
-				<resource value="Library"/>
-				<description value="Delete the library on the test server using the id of the Library"/>
-				<targetId value="library-col-logic"/>
+				<resource value="Measure" />
+				<description value="Evaluate a measure." />
+				<accept value="json" />
+				<contentType value="json" />
+				<params value="/${createMeasureId}/$evaluate-measure?patient=${createPatientId}&amp;periodStart=2017&amp;periodEnd=2017" />
+				<responseId value="measure-calc-report" />
 			</operation>
 		</action>
-	</teardown>
+		<action>
+			<assert>
+				<description value="Confirm that the returned HTTP status is 200(OK)." />
+				<direction value="response" />
+				<responseCode value="200" />
+			</assert>
+		</action>
+		<action>
+			<assert>
+				<description value="Confirm that the returned format is JSON. Warning only as the server may not support the return of response content." />
+				<contentType value="json" />
+				<warningOnly value="true" />
+			</assert>
+		</action>
+		<action>
+			<assert>
+				<description value="Confirm that the return type is MeasureReport. Warning only as the server may not support the return of response content." />
+				<resource value="MeasureReport" />
+			</assert>
+		</action>
+		<action>
+			<assert>
+				<description value="Confirm that the returned MeasureReport contains the expected initial population." />
+				<operator value="equals" />
+				<path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='initial-population']]]]/fhir:count/@value" />
+				<value value="1" />
+			</assert>
+		</action>
+		<action>
+			<assert>
+				<description value="Confirm that the returned MeasureReport contains the expected denominator." />
+				<operator value="equals" />
+				<path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='denominator']]]]/fhir:count/@value" />
+				<value value="1" />
+			</assert>
+		</action>
+		<action>
+			<assert>
+				<description value="Confirm that the returned MeasureReport contains the expected numerator." />
+				<operator value="equals" />
+				<path value="//fhir:MeasureReport/fhir:group/fhir:population[fhir:code[fhir:coding[fhir:code[@value='numerator']]]]/fhir:count/@value" />
+				<value value="1" />
+			</assert>
+		</action>
+	</test>
+
+	<!-- <teardown>
+		<action>
+			<operation>
+				<type>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="delete" />
+				</type>
+				<resource value="Patient" />
+				<description value="Delete the patient resource on the test server using the id of the Patient." />
+				<params value="/${createPatientId}" />
+			</operation>
+		</action>
+		<action>
+			<operation>
+				<type>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="delete" />
+				</type>
+				<resource value="Observation" />
+				<description value="Delete the observation on the test server using the id of the Observation" />
+				<targetId value="test-Observation-32794" />
+			</operation>
+		</action>
+		<action>
+			<operation>
+				<type>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="delete" />
+				</type>
+				<resource value="Measure" />
+				<description value="Delete the measure resource on the test server" />
+				<params value="/${createMeasureId}" />
+			</operation>
+		</action>
+		<action>
+			<operation>
+				<type>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="delete" />
+				</type>
+				<resource value="Library" />
+				<description value="Delete the library on the test server using the id of the Library" />
+				<targetId value="library-col-logic" />
+			</operation>
+		</action>
+	</teardown> -->
 </TestScript>

--- a/lib/tests/testscripts/scripts/reporting/vte-data-requirements.xml
+++ b/lib/tests/testscripts/scripts/reporting/vte-data-requirements.xml
@@ -197,8 +197,8 @@
                 <description value="Create a measure on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <sourceId value="measure-vte-1-FHIR"/>
                 <responseId value="create-measure-response"/>
+                <sourceId value="measure-vte-1-FHIR"/>
             </operation>
         </action>
         <action>
@@ -222,7 +222,7 @@
                 <description value="Get the data requirements for the measure"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <url value="Measure/${createMeasureId}/$data-requirements"/>
+                <params value="/${createMeasureId}/$data-requirements"/>
                 <responseId value="data-requirements-result"/>
             </operation>
         </action>
@@ -241,10 +241,10 @@
         <action>
             <assert>
                 <description value="Verify that the data requirements match those described by the measure logic"/>
-                <operator value="equals"/>
-                <path value="$.dataRequirement"/>
                 <compareToSourceId value="library-vte-1-FHIR"/>
                 <compareToSourcePath value="$.dataRequirement"/>
+                <operator value="equals"/>
+                <path value="$.dataRequirement"/>
             </assert>
         </action>
     </test>


### PR DESCRIPTION
This PR updates some of our TestScripts with changes made by AEGIS. This changes mainly involve

* Re-ordering some of the XML tags
* Using `params` instead of `url`. Not sure why, but this change was pretty consistent across all the TestScripts
* Some Spacing things

In addition, I realized that some of our older TestScripts weren't reflecting things we learned along the way, such as updating vs. creating, having a proper setup section/working teardown. So I have made some of those updates as well. The specific lists of changes for each TestScript are in the commit messages.

Ensure the TestScripts still work with the following commands:

* measure-col $data-requirements`brake crucible:execute[<base stu3 url>,stu3,col-data-requirements]`
* measure-col $submit-data `brake crucible:execute[<base stu3 url>,stu3,testscript-example-submit-data]` NOTE: I commented out the teardown section for now until we resolve the concerns I have about it (following up on this in our slack channel)
* measure-vte-1-FHIR $data-requirements `brake crucible:execute[<base stu3 url>,stu3,vte-data-requirements]`
* measure-col multisystem $evaluate-measure `brake crucible:execute_multiserver[<base stu3 url 1>, <base stu3 url 2>,stu3,clinical-reasoning-c21-ccs-individual-multisystem-json]` (I use localhost and kanvix for the 2 servers)
