### PR TITLE
Fixture id updates for existing TestScripts

### DIFF
--- a/lib/tests/testscripts/scripts/reporting/_reference/resources/Measure/measure-col.json
+++ b/lib/tests/testscripts/scripts/reporting/_reference/resources/Measure/measure-col.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Measure",
-  "id": "measure-col",
+  "id": "MitreTestScript-measure-col",
   "meta": {
     "versionId": "2",
     "lastUpdated": "2018-12-04T19:16:14.862+00:00"
@@ -33,7 +33,7 @@
   ],
   "library": [
     {
-      "reference": "Library/library-col-logic"
+      "reference": "Library/MitreTestScript-library-col-logic"
     }
   ],
   "scoring": {

--- a/lib/tests/testscripts/scripts/reporting/_reference/resources/Patient/test-Patient-410.json
+++ b/lib/tests/testscripts/scripts/reporting/_reference/resources/Patient/test-Patient-410.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "Patient",
-    "id": "test-Patient-410",
+    "id": "MitreTestScript-test-Patient-410",
     "meta": {
         "versionId": "1",
         "lastUpdated": "2019-01-12T10:53:57.847+00:00",

--- a/lib/tests/testscripts/scripts/reporting/_reference/resources/submit-data-parameters.json
+++ b/lib/tests/testscripts/scripts/reporting/_reference/resources/submit-data-parameters.json
@@ -4,13 +4,14 @@
     {
       "name": "measure-report",
       "resource": {
+        "id": "MitreTestScript-col-individual-report",
         "resourceType": "MeasureReport",
         "type": "individual",
         "measure": {
-          "reference": "Measure/measure-col"
+          "reference": "Measure/MitreTestScript-measure-col"
         },
         "patient": {
-          "reference": "Patient/test-Patient-410"
+          "reference": "Patient/MitreTestScript-test-Patient-410"
         },
         "period": {
           "start": "2017-01-01T00:00:00+00:00",
@@ -22,7 +23,7 @@
       "name": "resource",
       "resource": {
         "resourceType": "Observation",
-        "id": "test-Observation-32794",
+        "id": "MitreTestScript-test-Observation-32794",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2019-01-23T18:19:39.465+00:00",
@@ -64,7 +65,7 @@
           ]
         },
         "subject": {
-          "reference": "Patient/test-Patient-410",
+          "reference": "Patient/MitreTestScript-test-Patient-410",
           "display": "Bobbie Simon Jackson"
         },
         "effectiveDateTime": "2017-01-07T00:08:00-05:00",

--- a/lib/tests/testscripts/scripts/reporting/col-collect-data.xml
+++ b/lib/tests/testscripts/scripts/reporting/col-collect-data.xml
@@ -35,11 +35,6 @@
     </fixture>
 
     <variable>
-        <name value="createMeasureId"/>
-        <path value="Measure/id"/>
-        <sourceId value="create-measure-response"/>
-    </variable>
-    <variable>
         <name value="periodStart"/>
         <defaultValue value="2017"/>
     </variable>
@@ -74,20 +69,21 @@
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-                    <code value="create"/>
+                    <code value="update"/>
                 </type>
                 <resource value="Measure"/>
-                <description value="Create a measure on the server"/>
+                <description value="Update or create a measure on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
+                <params value="/MitreTestScript-measure-col"/>
                 <sourceId value="measure-col"/>
-                <responseId value="create-measure-response"/>
             </operation>
         </action>
         <action>
             <assert>
-                <description value="Confirm that the returned HTTP status is 201(Created)."/>
-                <response value="created"/>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                <operator value="in"/>
+                <responseCode value="200,201"/>
             </assert>
         </action>
         <action>
@@ -100,9 +96,16 @@
                 <description value="Create a patient that falls into the IPOP"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/test-Patient-410"/>
+                <params value="/MitreTestScript-test-Patient-410"/>
                 <sourceId value="test-Patient-410"/>
             </operation>
+        </action>
+         <action>
+            <assert>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                <operator value="in"/>
+                <responseCode value="200,201"/>
+            </assert>
         </action>
     </setup>
 
@@ -119,7 +122,7 @@
                 <description value="Collect data for the measure"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <url value="Measure/${createMeasureId}/$collect-data?periodStart=${periodStart}&amp;periodEnd=${periodEnd}"/>
+                <params value="/${createMeasureId}/$collect-data?periodStart=${periodStart}&amp;periodEnd=${periodEnd}"/>
                 <responseId value="collect-data-result"/>
             </operation>
         </action>
@@ -146,7 +149,7 @@
             <assert>
                 <description value="Confirm that the returned data contains the Patient"/>
                 <operator value="notEmpty"/>
-                <path value="$.parameter[?(@.resource.id == 'test-Patient-410')]"/>
+                <path value="$.parameter[?(@.resource.id == 'MitreTestScript-test-Patient-410')]"/>
             </assert>
         </action>
     </test>
@@ -160,7 +163,29 @@
                 </type>
                 <resource value="Measure"/>
                 <description value="Delete the measure"/>
-                <params value="/${createMeasureId}"/>
+                <params value="/MitreTestScript-measure-col"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Delete the library"/>
+                <params value="/MitreTestScript-library-col-logic"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Patient"/>
+                <description value="Delete the patient"/>
+                <params value="/MitreTestScript-test-Patient-410"/>
             </operation>
         </action>
         <action>

--- a/lib/tests/testscripts/scripts/reporting/col-data-requirements.xml
+++ b/lib/tests/testscripts/scripts/reporting/col-data-requirements.xml
@@ -29,12 +29,6 @@
         </resource>
     </fixture>
 
-    <variable>
-        <name value="createMeasureId"/>
-        <path value="Measure/id"/>
-        <sourceId value="create-measure-response"/>
-    </variable>
-
     <setup>
         <action>
             <operation>
@@ -46,7 +40,7 @@
                 <description value="Update or create a library on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/library-col-logic"/>
+                <params value="/MitreTestScript-library-col-logic"/>
                 <sourceId value="library-col-logic"/>
             </operation>
         </action>
@@ -61,20 +55,21 @@
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-                    <code value="create"/>
+                    <code value="update"/>
                 </type>
                 <resource value="Measure"/>
-                <description value="Create a measure on the server"/>
+                <description value="Update or create a measure on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <responseId value="create-measure-response"/>
+                <params value="/MitreTestScript-measure-col"/>
                 <sourceId value="measure-col"/>
             </operation>
         </action>
         <action>
             <assert>
-                <description value="Confirm that the returned HTTP status is 201(Created)."/>
-                <response value="created"/>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                <operator value="in"/>
+                <responseCode value="200,201"/>
             </assert>
         </action>
     </setup>
@@ -92,7 +87,7 @@
                 <description value="Get the data requirements for the measure"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/${createMeasureId}/$data-requirements"/>
+                <params value="/MitreTestScript-measure-col/$data-requirements"/>
                 <responseId value="data-requirements-result"/>
             </operation>
         </action>
@@ -127,8 +122,19 @@
                     <code value="delete"/>
                 </type>
                 <resource value="Measure"/>
-                <description value="Delete the measure"/>
-                <params value="/${createMeasureId}"/>
+                <description value="Delete the Measure"/>
+                <params value="/MitreTestScript-measure-col"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Delete the Library"/>
+                <params value="/MitreTestScript-library-col-logic"/>
             </operation>
         </action>
     </teardown>

--- a/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
+++ b/lib/tests/testscripts/scripts/reporting/multisystem-evaluate-measure.xml
@@ -52,16 +52,7 @@
     <profile id="measurereport-profile">
         <reference value="http://hl7.org/fhir/StructureDefinition/MeasureReport" />
     </profile>
-    <variable>
-        <name value="dest1CreateMeasureId" />
-        <path value="Measure/id" />
-        <sourceId value="dest1-create-measure-response" />
-    </variable>
-    <variable>
-        <name value="dest2CreateMeasureId" />
-        <path value="Measure/id" />
-        <sourceId value="dest2-create-measure-response" />
-    </variable>
+
     <variable>
         <name value="dest1CreatePatientId" />
         <path value="Patient/id" />
@@ -89,11 +80,11 @@
                     <code value="update" />
                 </type>
                 <resource value="Library" />
-                <description value="Create or update a library on the first server" />
+                <description value="Update or create a library on the first server" />
                 <accept value="json" />
                 <contentType value="json" />
                 <destination value="1" />
-                <params value="/library-col-logic" />
+                <params value="/MitreTestScript-library-col-logic" />
                 <sourceId value="library-col-logic" />
             </operation>
         </action>
@@ -108,42 +99,44 @@
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes" />
-                    <code value="create" />
+                    <code value="update" />
                 </type>
                 <resource value="Measure" />
-                <description value="Create a measure on the first server" />
+                <description value="Update or create a measure on the first server" />
                 <accept value="json" />
                 <contentType value="json" />
                 <destination value="1" />
-                <responseId value="dest1-create-measure-response" />
+                <params value="/MitreTestScript-measure-col" />
                 <sourceId value="measure-col" />
             </operation>
         </action>
         <action>
             <assert>
-                <description value="Confirm that the returned HTTP status is 201(Created)." />
-                <response value="created" />
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+                <operator value="in" />
+                <responseCode value="200,201" />
             </assert>
         </action>
         <action>
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes" />
-                    <code value="create" />
+                    <code value="update" />
                 </type>
                 <resource value="Patient" />
-                <description value="Create a patient on the first server" />
+                <description value="Update or create a patient on the first server" />
                 <accept value="json" />
                 <contentType value="json" />
                 <destination value="1" />
-                <responseId value="dest1-create-patient-response" />
+                <params value="/MitreTestScript-test-Patient-410" />
                 <sourceId value="fixture-create-patient" />
             </operation>
         </action>
         <action>
             <assert>
-                <description value="Confirm that the returned HTTP status is 201(Created)." />
-                <response value="created" />
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+                <operator value="in" />
+                <responseCode value="200,201" />
             </assert>
         </action>
         <action>
@@ -153,11 +146,11 @@
                     <code value="update" />
                 </type>
                 <resource value="Library" />
-                <description value="Create or update a library on the first server" />
+                <description value="Create or update a library on the second server" />
                 <accept value="json" />
                 <contentType value="json" />
                 <destination value="2" />
-                <params value="/library-col-logic" />
+                <params value="/MitreTestScript-library-col-logic" />
                 <sourceId value="library-col-logic" />
             </operation>
         </action>
@@ -172,42 +165,44 @@
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes" />
-                    <code value="create" />
+                    <code value="update" />
                 </type>
                 <resource value="Measure" />
                 <description value="Create a measure on the second server" />
                 <accept value="json" />
                 <contentType value="json" />
                 <destination value="2" />
-                <responseId value="dest2-create-measure-response" />
+                <params value="/MitreTestScript-measure-col" />
                 <sourceId value="measure-col" />
             </operation>
         </action>
         <action>
             <assert>
-                <description value="Confirm that the returned HTTP status is 201(Created)." />
-                <response value="created" />
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+                <operator value="in" />
+                <responseCode value="200,201" />
             </assert>
         </action>
         <action>
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes" />
-                    <code value="create" />
+                    <code value="update" />
                 </type>
                 <resource value="Patient" />
                 <description value="Create a patient on the second server" />
                 <accept value="json" />
                 <contentType value="json" />
                 <destination value="2" />
-                <responseId value="dest2-create-patient-response" />
+                <params value="/MitreTestScript-test-Patient-410" />
                 <sourceId value="fixture-create-patient" />
             </operation>
         </action>
         <action>
             <assert>
-                <description value="Confirm that the returned HTTP status is 200(OK)" />
-                <response value="created" />
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+                <operator value="in" />
+                <responseCode value="200,201" />
             </assert>
         </action>
     </setup>
@@ -227,7 +222,7 @@
                 <accept value="xml" />
                 <contentType value="xml" />
                 <destination value="1" />
-                <params value="/${dest1CreateMeasureId}/$evaluate-measure?patient=${dest1CreatePatientId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}" />
+                <params value="/MitreTestScript-measure-col/$evaluate-measure?patient=MitreTestScript-test-Patient-410&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}" />
                 <responseId value="dest1-measurereport" />
             </operation>
         </action>
@@ -323,7 +318,7 @@
                 <accept value="xml" />
                 <contentType value="xml" />
                 <destination value="2" />
-                <params value="/${dest2CreateMeasureId}/$evaluate-measure?patient=${dest2CreatePatientId}&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}" />
+                <params value="/MitreTestScript-measure-col/$evaluate-measure?patient=MitreTestScript-test-Patient-410&amp;periodStart=${PeriodStart}&amp;periodEnd=${PeriodEnd}" />
             </operation>
         </action>
         <action>
@@ -417,7 +412,7 @@
                 <resource value="Patient" />
                 <description value="Delete the patient resource on the first server" />
                 <destination value="1" />
-                <params value="/${dest1CreatePatientId}" />
+                <params value="/MitreTestScript-test-Patient-410" />
             </operation>
         </action>
         <action>
@@ -429,7 +424,7 @@
                 <resource value="Patient" />
                 <description value="Delete the patient resource on the second server" />
                 <destination value="2" />
-                <params value="/${dest2CreatePatientId}" />
+                <params value="/MitreTestScript-test-Patient-410" />
             </operation>
         </action>
         <action>
@@ -441,7 +436,7 @@
                 <resource value="Measure" />
                 <description value="Delete the measure resource on the first server" />
                 <destination value="1" />
-                <params value="/${dest1CreateMeasureId}" />
+                <params value="/MitreTestScript-measure-col" />
             </operation>
         </action>
         <action>
@@ -453,7 +448,31 @@
                 <resource value="Measure" />
                 <description value="Delete the measure resource on the second server" />
                 <destination value="2" />
-                <params value="/${dest2CreateMeasureId}" />
+                <params value="/MitreTestScript-measure-col" />
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="delete" />
+                </type>
+                <resource value="Library" />
+                <description value="Delete the Library resource on the first server" />
+                <destination value="1" />
+                <params value="/MitreTestScript-library-col-logic" />
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes" />
+                    <code value="delete" />
+                </type>
+                <resource value="Library" />
+                <description value="Delete the Library resource on the second server" />
+                <destination value="2" />
+                <params value="/MitreTestScript-library-col-logic" />
             </operation>
         </action>
     </teardown>

--- a/lib/tests/testscripts/scripts/reporting/submit-data.xml
+++ b/lib/tests/testscripts/scripts/reporting/submit-data.xml
@@ -202,16 +202,16 @@
 
 	<teardown>
 		<action>
-            <operation>
-                <type>
-                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-                    <code value="delete"/>
-                </type>
-                <resource value="MeasureReport"/>
-                <description value="Delete the MeasureReport from $submit-data"/>
-                <params value="/MitreTestScript-col-individual-report"/>
-            </operation>
-        </action>
+			<operation>
+				<type>
+					<system value="http://hl7.org/fhir/testscript-operation-codes"/>
+					<code value="delete"/>
+				</type>
+				<resource value="MeasureReport"/>
+				<description value="Delete the MeasureReport from $submit-data"/>
+				<params value="/MitreTestScript-col-individual-report"/>
+			</operation>
+		</action>
 		<action>
 			<operation>
 				<type>

--- a/lib/tests/testscripts/scripts/reporting/submit-data.xml
+++ b/lib/tests/testscripts/scripts/reporting/submit-data.xml
@@ -23,6 +23,7 @@
 			<display value="United States of America (the)" />
 		</coding>
 	</jurisdiction>
+
 	<fixture id="library-col-logic">
 		<resource>
 			<reference value="./_reference/resources/Library/library-col-logic.json" />
@@ -43,16 +44,6 @@
 			<reference value="./_reference/resources/submit-data-parameters.json" />
 		</resource>
 	</fixture>
-	<variable>
-		<name value="createMeasureId" />
-		<path value="Measure/id" />
-		<sourceId value="create-measure-response" />
-	</variable>
-	<variable>
-		<name value="createPatientId" />
-		<defaultValue value="test-Patient-410" />
-		<sourceId value="fixture-create-patient" />
-	</variable>
 
 	<setup>
 		<action>
@@ -65,7 +56,7 @@
 				<description value="Create or update a library" />
 				<accept value="json" />
 				<contentType value="json" />
-				<params value="/library-col-logic" />
+				<params value="/MitreTestScript-library-col-logic" />
 				<sourceId value="library-col-logic"/>
 			</operation>
 		</action>
@@ -80,20 +71,21 @@
 			<operation>
 				<type>
 					<system value="http://hl7.org/fhir/testscript-operation-codes" />
-					<code value="create" />
+					<code value="update" />
 				</type>
 				<resource value="Measure" />
-				<description value="Create a measure" />
+				<description value="Update or create a measure" />
 				<accept value="json" />
 				<contentType value="json" />
-				<responseId value="create-measure-response" />
+				<params value="/MitreTestScript-measure-col" />
 				<sourceId value="measure-col" />
 			</operation>
 		</action>
 		<action>
 			<assert>
-				<description value="Confirm that the returned HTTP status is 201 (Created)" />
-				<response value="created" />
+				<description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)." />
+				<operator value="in" />
+				<responseCode value="200,201" />
 			</assert>
 		</action>
 		<action>
@@ -106,7 +98,7 @@
 				<description value="Create a patient" />
 				<accept value="json" />
 				<contentType value="json" />
-				<params value="/${createPatientId}" />
+				<params value="/MitreTestScript-test-Patient-410" />
 				<sourceId value="fixture-create-patient" />
 			</operation>
 		</action>
@@ -132,7 +124,7 @@
 				<accept value="json" />
 				<contentType value="json" />
 				<encodeRequestUrl value="false" />
-				<params value="/${createMeasureId}" />
+				<params value="/MitreTestScript-measure-col" />
 				<sourceId value="submit-data-parameters" />
 			</operation>
 		</action>
@@ -158,7 +150,7 @@
 				<description value="Evaluate a measure." />
 				<accept value="json" />
 				<contentType value="json" />
-				<params value="/${createMeasureId}/$evaluate-measure?patient=${createPatientId}&amp;periodStart=2017&amp;periodEnd=2017" />
+				<params value="/MitreTestScript-measure-col/$evaluate-measure?patient=MitreTestScript-test-Patient-410&amp;periodStart=2017&amp;periodEnd=2017" />
 				<responseId value="measure-calc-report" />
 			</operation>
 		</action>
@@ -208,18 +200,18 @@
 		</action>
 	</test>
 
-	<!-- <teardown>
+	<teardown>
 		<action>
-			<operation>
-				<type>
-					<system value="http://hl7.org/fhir/testscript-operation-codes" />
-					<code value="delete" />
-				</type>
-				<resource value="Patient" />
-				<description value="Delete the patient resource on the test server using the id of the Patient." />
-				<params value="/${createPatientId}" />
-			</operation>
-		</action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="MeasureReport"/>
+                <description value="Delete the MeasureReport from $submit-data"/>
+                <params value="/MitreTestScript-col-individual-report"/>
+            </operation>
+        </action>
 		<action>
 			<operation>
 				<type>
@@ -228,7 +220,18 @@
 				</type>
 				<resource value="Observation" />
 				<description value="Delete the observation on the test server using the id of the Observation" />
-				<targetId value="test-Observation-32794" />
+				<params value="/MitreTestScript-test-Observation-32794" />
+			</operation>
+		</action>
+		<action>
+			<operation>
+				<type>
+					<system value="http://hl7.org/fhir/testscript-operation-codes" />
+					<code value="delete" />
+				</type>
+				<resource value="Patient" />
+				<description value="Delete the patient resource on the test server using the id of the Patient." />
+				<params value="/MitreTestScript-test-Patient-410" />
 			</operation>
 		</action>
 		<action>
@@ -239,7 +242,7 @@
 				</type>
 				<resource value="Measure" />
 				<description value="Delete the measure resource on the test server" />
-				<params value="/${createMeasureId}" />
+				<params value="/MitreTestScript-measure-col" />
 			</operation>
 		</action>
 		<action>
@@ -250,8 +253,8 @@
 				</type>
 				<resource value="Library" />
 				<description value="Delete the library on the test server using the id of the Library" />
-				<targetId value="library-col-logic" />
+				<params value="/MitreTestScript-library-col-logic" />
 			</operation>
 		</action>
-	</teardown> -->
+	</teardown>
 </TestScript>

--- a/lib/tests/testscripts/scripts/reporting/vte-data-requirements.xml
+++ b/lib/tests/testscripts/scripts/reporting/vte-data-requirements.xml
@@ -54,12 +54,6 @@
         </resource>
     </fixture>
 
-    <variable>
-        <name value="createMeasureId"/>
-        <path value="Measure/id"/>
-        <sourceId value="create-measure-response"/>
-    </variable>
-
     <setup>
         <action>
             <operation>
@@ -71,7 +65,7 @@
                 <description value="Update or create a library on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/library-fhir-model-definition"/>
+                <params value="/MitreTestScript-library-fhir-model-definition"/>
                 <sourceId value="library-fhir-model-definition"/>
             </operation>
         </action>
@@ -92,7 +86,7 @@
                 <description value="Update or create a library on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/library-fhir-helpers"/>
+                <params value="/MitreTestScript-library-fhir-helpers"/>
                 <sourceId value="library-fhir-helpers"/>
             </operation>
         </action>
@@ -113,7 +107,7 @@
                 <description value="Update or create a library on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/library-mat-global-common-functions-FHIR"/>
+                <params value="/MitreTestScript-library-mat-global-common-functions-FHIR"/>
                 <sourceId value="library-mat-global-common-functions-FHIR"/>
             </operation>
         </action>
@@ -134,7 +128,7 @@
                 <description value="Update or create a library on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/library-supplemental-data-elements-FHIR"/>
+                <params value="/MitreTestScript-library-supplemental-data-elements-FHIR"/>
                 <sourceId value="library-supplemental-data-elements-FHIR"/>
             </operation>
         </action>
@@ -155,7 +149,7 @@
                 <description value="Update or create a library on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/library-vte-icu-FHIR"/>
+                <params value="/MitreTestScript-library-vte-icu-FHIR"/>
                 <sourceId value="library-vte-icu-FHIR"/>
             </operation>
         </action>
@@ -176,7 +170,7 @@
                 <description value="Update or create a library on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/library-vte-1-FHIR"/>
+                <params value="/MitreTestScript-library-vte-1-FHIR"/>
                 <sourceId value="library-vte-1-FHIR"/>
             </operation>
         </action>
@@ -191,20 +185,21 @@
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-                    <code value="create"/>
+                    <code value="update"/>
                 </type>
                 <resource value="Measure"/>
-                <description value="Create a measure on the server"/>
+                <description value="Update or create a measure on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <responseId value="create-measure-response"/>
+                <params value="/MitreTestScript-measure-vte-1-FHIR"/>
                 <sourceId value="measure-vte-1-FHIR"/>
             </operation>
         </action>
         <action>
             <assert>
-                <description value="Confirm that the returned HTTP status is 201(Created)."/>
-                <response value="created"/>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                <operator value="in"/>
+                <responseCode value="200,201"/>
             </assert>
         </action>
     </setup>
@@ -222,7 +217,7 @@
                 <description value="Get the data requirements for the measure"/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/${createMeasureId}/$data-requirements"/>
+                <params value="/MitreTestScript-measure-vte-1-FHIR/$data-requirements"/>
                 <responseId value="data-requirements-result"/>
             </operation>
         </action>
@@ -258,7 +253,73 @@
                 </type>
                 <resource value="Measure"/>
                 <description value="Delete the measure"/>
-                <params value="/${createMeasureId}"/>
+                <params value="/MitreTestScript-measure-vte-1-FHIR"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Delete a library on the server"/>
+                <params value="/MitreTestScript-library-vte-1-FHIR"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Delete a library on the server"/>
+                <params value="/MitreTestScript-library-vte-icu-FHIR"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Delete a library on the server"/>
+                <params value="/MitreTestScript-library-supplemental-data-elements-FHIR"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Delete a library on the server"/>
+                <params value="/MitreTestScript-library-mat-global-common-functions-FHIR"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Delete a library on the server"/>
+                <params value="/MitreTestScript-library-fhir-helpers"/>
+            </operation>
+        </action>
+        <action>
+            <operation>
+                <type>
+                    <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                    <code value="delete"/>
+                </type>
+                <resource value="Library"/>
+                <description value="Delete a library on the server"/>
+                <params value="/MitreTestScript-library-fhir-model-definition"/>
             </operation>
         </action>
     </teardown>

--- a/lib/tests/testscripts/scripts/reporting/vte-evaluate-measure.xml
+++ b/lib/tests/testscripts/scripts/reporting/vte-evaluate-measure.xml
@@ -65,11 +65,6 @@
     </fixture>
 
     <variable>
-        <name value="createMeasureId"/>
-        <path value="Measure/id"/>
-        <sourceId value="create-measure-response"/>
-    </variable>
-    <variable>
         <name value="periodStart"/>
         <defaultValue value="2018-01-01"/>
     </variable>
@@ -219,20 +214,20 @@
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-                    <code value="create"/>
+                    <code value="update"/>
                 </type>
                 <resource value="Measure"/>
-                <description value="Create a measure on the server"/>
+                <description value="Update or create a measure on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
+                <params value="/MitreTestScript-measure-vte-1-FHIR"/>
                 <sourceId value="measure-vte-1-FHIR"/>
-                <responseId value="create-measure-response"/>
             </operation>
         </action>
         <action>
             <assert>
                 <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
-                <operator value="in" />
+                <operator value="in"/>
                 <responseCode value="200,201"/>
             </assert>
         </action>
@@ -297,7 +292,7 @@
                 <description value="Evaluate measure with server assigned resource id."/>
                 <accept value="json"/>
                 <contentType value="json"/>
-                <params value="/${createMeasureId}/$evaluate-measure?periodStart=${periodStart}&amp;periodEnd=${periodEnd}"/>
+                <params value="/MitreTestScript-measure-vte-1-FHIR/$evaluate-measure?periodStart=${periodStart}&amp;periodEnd=${periodEnd}"/>
             </operation>
         </action>
         <action>
@@ -325,7 +320,7 @@
                 </type>
                 <resource value="Measure"/>
                 <description value="Delete the measure"/>
-                <params value="/${createMeasureId}"/>
+                <params value="/MitreTestScript-measure-vte-1-FHIR"/>
             </operation>
         </action>
         <action>

--- a/lib/tests/testscripts/scripts/reporting/vte-submit-data.xml
+++ b/lib/tests/testscripts/scripts/reporting/vte-submit-data.xml
@@ -78,11 +78,6 @@
         <path value="$.parameter[?(@.resource.resourceType == 'Encounter')].resource.id"/>
         <sourceId value="vte-submit-data-input"/>
     </variable>
-    <variable>
-        <name value="createMeasureId"/>
-        <path value="Measure/id"/>
-        <sourceId value="create-measure-response"/>
-    </variable>
 
     <setup>
         <action>
@@ -215,20 +210,21 @@
             <operation>
                 <type>
                     <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-                    <code value="create"/>
+                    <code value="update"/>
                 </type>
                 <resource value="Measure"/>
-                <description value="Create a measure on the server"/>
+                <description value="Update or create a measure on the server"/>
                 <accept value="json"/>
                 <contentType value="json"/>
+                <params value="/MitreTestScript-measure-vte-1-FHIR"/>
                 <sourceId value="measure-vte-1-FHIR"/>
-                <responseId value="create-measure-response"/>
             </operation>
         </action>
         <action>
             <assert>
-                <description value="Confirm that the returned HTTP status is 201(Created)."/>
-                <response value="created"/>
+                <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                <operator value="in"/>
+                <responseCode value="200,201"/>
             </assert>
         </action>
     </setup>
@@ -246,7 +242,7 @@
                 <accept value="json"/>
                 <contentType value="json"/>
                 <encodeRequestUrl value="true"/>
-                <params value="${createMeasureId}"/>
+                <params value="MitreTestScript-measure-vte-1-FHIR"/>
                 <sourceId value="vte-submit-data-input"/>
             </operation>
         </action>
@@ -304,7 +300,7 @@
                 </type>
                 <resource value="Measure"/>
                 <description value="Delete the measure"/>
-                <params value="/${createMeasureId}"/>
+                <params value="/MitreTestScript-measure-vte-1-FHIR"/>
             </operation>
         </action>
         <action>


### PR DESCRIPTION
This PR updates the remaining TestScripts that were not following our new fixture id approach. Such TestScripts are:

* measure-col
    * $collect-data (`brake crucible:execute[<base stu3 url>,stu3,col-collect-data]`)
    * $data-requirements (`brake crucible:execute[<base stu3 url>,stu3,col-data-requirements]`)
    * $submit-data (`brake crucible:execute[<base stu3 url>,stu3,testscript-example-submit-data]`)
    * $evaluate-measure (multiserver) (`brake crucible:execute_multiserver[<base stu3 url1>, <base stu3 url2>,stu3,clinical-reasoning-c21-ccs-individual-multisystem-json]`)
* measure-vte-1-FHIR
    * $data-requirements (`brake crucible:execute[<base stu3 url>,stu3,vte-data-requirements]`)
    * $evaluate-measure (`brake crucible:execute[<base stu3 url>,stu3,vte-evaluate-measure]`)

The rest of the TestScripts either already had this approach implemented, or were made by someone other than us (MRP $data-requirements and $submit-data).

There are a few things that can be tested to verify that the approach is working for all the TestScripts:
* Ensure that all parts of the TestScripts pass
* Ensure that there are no resources with the `MitreTestScript-` id prefix on the server after the TestScript passes
* Ensure that even if we comment out the teardown section, run the test script, uncomment out the teardown section, and run it again, it passes without getting that 409 Conflict error we have seen in the past.