### PR TITLE
R4 ImplementationGuide generator incorrect fhirVersion cardinality

### DIFF
--- a/lib/resource_generator.rb
+++ b/lib/resource_generator.rb
@@ -570,8 +570,6 @@ module Crucible
         when FHIR::Immunization
           resource.doseQuantity.comparator = nil unless resource.doseQuantity.nil?
           resource.status = ['completed','entered-in-error'].sample
-        when FHIR::ImplementationGuide
-          resource.fhirVersion = "4.0.0"
         when FHIR::Linkage
           if resource.item.length == 1
             resource.item << resource.item.first # must have 2


### PR DESCRIPTION
Our generator hardcoded `fhirVersion = "4.0.0"` even though the max cardinality is `*`.

FYI @radamson -- this exposes a potential underlying issue -- for some reason our validator accepted what appears to be an incorrect resource.  Could you investigate as you are improving this in fhir_models?

Addresses #172.