### PR TITLE
Update search tests to use count if total not provided in bundle

### DIFF
--- a/lib/tests/suites/search_test.rb
+++ b/lib/tests/suites/search_test.rb
@@ -199,15 +199,19 @@ module Crucible
 
         replyB = @client.read_feed(@resource_class)
 
+        # bundle.total is optional
+        total = reply.resource.total
+        total = reply.resource&.entry&.count if total.nil?
+        totalB = replyB.resource.total
+        totalB = replyB.resource&.entry&.count if totalB.nil?
+
         # AuditEvent
         if resource_class == get_resource(:AuditEvent)
-          count = (reply.resource.total-replyB.resource.total).abs
+          count = (total-totalB).abs
           assert (count <= 1), 'Searching without criteria did not return all the results.'
         else
-          assert !replyB.resource.nil?, 'Searching without criteria did not return any results.'
-          assert !reply.resource.nil?, 'Searching without criteria did not return any results.'
-          assert !replyB.resource.total.nil?, 'Search bundle returned does not report a total entry count.'
-          assert !reply.resource.total.nil?, 'Search bundle returned does not report a total entry count.'
+          assert_operator :greaterThan, totalB, 0, 'Searching without criteria did not return any results.'
+          assert_operator :greaterThan, total, 0, 'Searching without criteria did not return any results.'
           assert_equal replyB.resource.total, reply.resource.total, 'Searching without criteria did not return all the results.'
         end
       end

--- a/lib/tests/suites/sprinkler_search_test.rb
+++ b/lib/tests/suites/sprinkler_search_test.rb
@@ -182,9 +182,14 @@ module Crucible
           }
         }
         reply = @client.search(get_resource(:Patient), options)
+
+        # bundle.total is optional
+        total = reply.resource.total
+        total = reply.resource&.entry&.count if total.nil?
+
         assert_response_ok(reply)
         assert_bundle_response(reply)
-        assert_equal expected, reply.resource.total, 'The server did not report the expected number of results.'
+        assert_equal expected, total, 'The server did not report the expected number of results.'
       end
 
       test "SE04#{action[0]}", 'Search patient resource on given name' do
@@ -226,9 +231,14 @@ module Crucible
           }
         }
         reply = @client.search(get_resource(:Patient), options)
+        
+        # bundle.total is optional
+        total = reply.resource.total
+        total = reply.resource&.entry&.count if total.nil?
+
         assert_response_ok(reply)
         assert_bundle_response(reply)
-        assert_equal expected, reply.resource.total, 'The server did not report the expected number of results.'
+        assert_equal expected, total, 'The server did not report the expected number of results.'
       end
 
       test "SE05.0#{action[0]}", 'Search condition by patient reference url (partial)' do
@@ -530,9 +540,14 @@ module Crucible
           }
         }
         reply = @client.search(get_resource(:Condition), options)
+
+        # bundle.total is optional
+        total = reply.resource.total
+        total = reply.resource&.entry&.count if total.nil?
+
         assert_response_ok(reply)
         assert_bundle_response(reply)
-        assert reply.resource.total > 0, 'The server should have Conditions that _include=Condition:patient.'
+        assert_operator :greaterThan, total, 0, 'The server should have Conditions that _include=Condition:patient.'
         has_patient = false
         reply.resource.entry.each do |entry|
           has_patient = true if (entry.resource && entry.resource.class == get_resource(:Patient))
@@ -561,9 +576,14 @@ module Crucible
           }
         }
         reply = @client.search(get_resource(:Patient), options)
+
+        # bundle.total is optional
+        total = reply.resource.total
+        total = reply.resource&.entry&.count if total.nil?
+
         assert_response_ok(reply)
         assert_bundle_response(reply)
-        assert reply.resource.total > 0, 'The server should have Patients that are _revinclude=Condition:patient.'
+        assert_operator :greaterThan, total, 0, 'The server should have Patients that are _revinclude=Condition:patient.'
         has_condition = false
         reply.resource.entry.each do |entry|
           has_condition = true if (entry.resource && entry.resource.class == get_resource(:Condition))
@@ -669,9 +689,14 @@ module Crucible
           }
         }
         reply = @client.search(get_resource(:Patient), options)
+        
+        # bundle.total is optional
+        total = reply.resource.total
+        total = reply.resource&.entry&.count if total.nil?
+        
         assert_response_ok(reply)
         assert_bundle_response(reply)
-        assert_equal expected, reply.resource.total, 'The server did not report the expected number of results.'
+        assert_equal expected, total, 'The server did not report the expected number of results.'
       end
 
       test "SE24#{action[0]}", 'Search with non-existing parameter' do


### PR DESCRIPTION
As mentioned in https://github.com/fhir-crucible/plan_executor/issues/140 , the total field of a bundle can be provided in search results but is not required. This PR updates the Search and Sprinkler Search test suites to use a count of the resources in the bundle if no total is provided, just as https://github.com/fhir-crucible/plan_executor/pull/159 updated the History test suites. It was also mentioned in the discussion of PR 159 that pagination is required to get an accurate count, but since the tests in question aren't querying large numbers of resources this is reasonably left to further implementation.