### PR TITLE
Fix transaction suite generated Condition resource

### DIFF
--- a/lib/resource_generator.rb
+++ b/lib/resource_generator.rb
@@ -206,7 +206,9 @@ module Crucible
           resource.subject.display = 'Patient'
         end
         resource.code = minimal_codeableconcept(system,code, namespace)
-        resource.verificationStatus = 'confirmed'
+        if namespace == 'FHIR::DSTU2'
+          resource.verificationStatus = 'confirmed'
+        end
         tag_metadata(resource)
       end
 
@@ -412,6 +414,19 @@ module Crucible
           #   resource.targetReference = textonly_reference('ValueSet') 
           # end
         when FHIR::Condition
+          # con-3
+          verification_status_is_entered_in_error = resource&.verificationStatus&.coding&.include?('entered-in-error')
+          category_is_problem_list_item = resource&.category&.find {|e| e&.coding&.include?("problem-list-item")}
+          if (!verification_status_is_entered_in_error || !category_is_problem_list_item)
+            clinical_status_code = ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].sample
+            resource.clinicalStatus = minimal_codeableconcept('http://hl7.org/fhir/ValueSet/condition-clinical', clinical_status_code)
+          end
+
+          # con-5
+          if resource&.verificationStatus&.coding&.include?('entered-in-error')
+            resource.clinicalStatus = nil
+          end
+
           if resource.onsetAge
             resource.onsetAge.system = 'http://unitsofmeasure.org'
             resource.onsetAge.code = 'a'
@@ -1079,6 +1094,11 @@ module Crucible
             resource.targetReference = textonly_reference('ValueSet', FHIR::STU3) 
           end
         when FHIR::STU3::Condition
+          # con-3
+          if resource.verificationStatus != 'entered-in-error'
+            resource.clinicalStatus = ['active', 'recurrence', 'inactive', 'remission', 'resolved'].sample
+          end
+
           if resource.onsetAge
             resource.onsetAge.system = 'http://unitsofmeasure.org'
             resource.onsetAge.code = 'a'

--- a/lib/tests/suites/transaction_test.rb
+++ b/lib/tests/suites/transaction_test.rb
@@ -170,9 +170,14 @@ module Crucible
         @obs2 = ResourceGenerator.minimal_observation('http://loinc.org','3141-9',100,'kg',@patient0.id)
         # obesity has been refuted
         @condition0.subject.reference = "Patient/#{@patient0.id}"
-        @condition0.clinicalStatus = 'resolved'
-        @condition0.verificationStatus = 'refuted'
         @condition0.abatementString = 'Abated at unknown date'
+        if fhir_version() == :r4
+          @condition0.clinicalStatus = ResourceGenerator.minimal_codeableconcept('http://hl7.org/fhir/ValueSet/condition-clinical', 'resolved')
+          @condition0.verificationStatus = ResourceGenerator.minimal_codeableconcept('http://hl7.org/fhir/ValueSet/condition-ver-status', 'refuted')
+        else
+          @condition0.clinicalStatus = 'resolved'
+          @condition0.verificationStatus = 'refuted'
+        end
 
         @client.begin_transaction
         @client.add_transaction_request('DELETE',"Observation/#{@obs0b.id}") if @obs0b && !@obs0b.id.nil? # delete first weight

--- a/lib/tests/suites/transaction_test.rb
+++ b/lib/tests/suites/transaction_test.rb
@@ -172,8 +172,8 @@ module Crucible
         @condition0.subject.reference = "Patient/#{@patient0.id}"
         @condition0.abatementString = 'Abated at unknown date'
         if fhir_version() == :r4
-          @condition0.clinicalStatus = ResourceGenerator.minimal_codeableconcept('http://hl7.org/fhir/ValueSet/condition-clinical', 'resolved')
-          @condition0.verificationStatus = ResourceGenerator.minimal_codeableconcept('http://hl7.org/fhir/ValueSet/condition-ver-status', 'refuted')
+          @condition0.clinicalStatus = ResourceGenerator.minimal_codeableconcept('http://terminology.hl7.org/CodeSystem/condition-clinical', 'resolved')
+          @condition0.verificationStatus = ResourceGenerator.minimal_codeableconcept('http://terminology.hl7.org/CodeSystem/condition-ver-status', 'refuted')
         else
           @condition0.clinicalStatus = 'resolved'
           @condition0.verificationStatus = 'refuted'

--- a/lib/tests/suites/transaction_test.rb
+++ b/lib/tests/suites/transaction_test.rb
@@ -75,6 +75,8 @@ module Crucible
         @condition0 = ResourceGenerator.minimal_condition('http://snomed.info/sct','414915002',patient0_id)
         @condition0.subject.reference = patient0_uri
 
+        ResourceGenerator.apply_invariants!(@condition0)
+
         @client.begin_transaction
         @client.add_transaction_request('POST',nil,@patient0).fullUrl = patient0_uri
         @client.add_transaction_request('POST',nil,@obs0a).fullUrl = "urn:uuid:#{SecureRandom.uuid}"
@@ -258,8 +260,9 @@ module Crucible
         assert_bundle_response(reply)
         assert_bundle_transactions_okay(reply)
 
-        count = (reply.resource.entry.first.resource.total rescue 0)
-        assert(count==1,"In a transaction, GET should execute last and in this case only return 1 result; found #{count}",reply.body)
+        total = reply.resource.entry.first.resource.total
+        total = reply&.resource&.entry&.first&.resource&.entry&.count if total.nil?
+        assert(total==1,"In a transaction, GET should execute last and in this case only return 1 result; found #{total}",reply.body)
         searchResultId = (reply.resource.entry.first.resource.entry.first.resource.id rescue nil)
         assert(searchResultId==@obs0a.id,"The GET search returned the wrong result. Expected Observation/#{@obs0a.id} but found Observation/#{searchResultId}.",reply.body)
 


### PR DESCRIPTION
I found some validation issues with the Condition resources used in the transaction test suite. This PR adjusts the minimal Condition resource generator, adds some invariant checks, and makes sure the fields added manually in the transaction suite conform to the invariants.