### PR TITLE
Fix a typo in Sprinkler Search Test

### DIFF
--- a/lib/tests/suites/sprinkler_search_test.rb
+++ b/lib/tests/suites/sprinkler_search_test.rb
@@ -73,7 +73,7 @@ module Crucible
         observation.code = get_resource(:CodeableConcept).new
         observation.code.coding = [ code ]
         observation.valueQuantity = get_resource(:Quantity).new
-        observation.valueQuantity.system = 'http://unitofmeasure.org'
+        observation.valueQuantity.system = 'http://unitsofmeasure.org'
         observation.valueQuantity.value = value
         observation.valueQuantity.unit = 'mmol'
         body = get_resource(:Coding).new


### PR DESCRIPTION
The UCUM url is unitsofmeasure.org not unitofmeasure.org.